### PR TITLE
Basic setup for fob option

### DIFF
--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -45,6 +45,7 @@ use Illuminate\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
  * @property string      mandate_id
  * @property int         monthly_subscription
  * @property string      gocardless_setup_id
+ * @property bool   postFob (false=collect, true=post)
  * @package BB\Entities
  */
 class User extends Model implements AuthenticatableContract, CanResetPasswordContract {
@@ -79,7 +80,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
     protected $fillable = [
         'given_name', 'family_name', 'email', 'secondary_email', 'display_name', 'announce_name', 'online_only', 'password', 'emergency_contact', 'phone',
         'monthly_subscription', 'profile_private', 'hash', 'rules_agreed',
-        'key_holder', 'key_deposit_payment_id', 'trusted', 'induction_completed', 'payment_method', 'active', 'status'
+        'key_holder', 'key_deposit_payment_id', 'trusted', 'induction_completed', 'payment_method', 'active', 'status', 'postFob'
     ];
 
 

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -174,7 +174,8 @@ class AccountController extends Controller
             'new_profile_photo',
             'profile_photo_private',
             'rules_agreed',
-            'visited_space'
+            'visited_space',
+            'postFob'
         );
 
         $this->userForm->validate($input);

--- a/app/Mailer/UserMailer.php
+++ b/app/Mailer/UserMailer.php
@@ -33,12 +33,14 @@ class UserMailer
                 $message->to($user->email, $user->name)->subject('Welcome to Hackspace Manchester!');
             });
     
-            $addressRepository = \App::make('BB\Repo\AddressRepository');
-            $address = $addressRepository->getActiveUserAddress($this->user->id);
-    
-            \Mail::queue('emails.welcome-admin', ['user'=>$user, 'address'=>$address], function ($message) use ($user,$address) {
-                $message->to('outreach@hacman.org.uk')->subject('New Member Alert');
-            });
+            if($user->postFob) {
+                $addressRepository = \App::make('BB\Repo\AddressRepository');
+                $address = $addressRepository->getActiveUserAddress($this->user->id);
+                
+                \Mail::queue('emails.welcome-admin', ['user'=>$user, 'address'=>$address], function ($message) use ($user,$address) {
+                    $message->to('outreach@hacman.org.uk')->subject('New Member Alert');
+                });
+            }
         }
     }
     

--- a/resources/views/account/create.blade.php
+++ b/resources/views/account/create.blade.php
@@ -162,6 +162,26 @@ Join Hackspace Manchester
 
 
     <div class="form-group {{ Notification::hasErrorDetail('rules_agreed', 'has-error has-feedback') }}">
+        <div class="well col-sm-9 col-lg-7 col-sm-offset-3">
+            <b>How would you like to get your fob for 24/7 access?</b>
+            <p>Your fob can be posted to you, or you can collect it from the space. Collecting from the space will require you attending an open evening, or arranging with an existing member for them to let you in so you can set up your fob.</p>
+            <div class="radio">
+                <label data-toggle="tooltip" title="Collect my fob from the space">
+                    {!! Form::radio('postFob', false, true) !!}
+                    Collect my fob from the space
+                </label>
+            </div>
+            <div class="radio">
+                <label data-toggle="tooltip" title="Have my fob posted to me">
+                    {!! Form::radio('postFob', true, false) !!}
+                    Have my fob posted to me (takes a few working days)
+                </label>
+            </div>
+        </div>
+    </div>
+
+
+    <div class="form-group {{ Notification::hasErrorDetail('rules_agreed', 'has-error has-feedback') }}">
         <div class="col-sm-9 col-lg-7 col-sm-offset-3">
             <span class="help-block">Please read the <a href="https://members.hacman.org.uk/resources/policy/rules" target="_blank">rules</a> and click the checkbox to confirm you agree to them</span>
             {!! Form::checkbox('rules_agreed', true, null, ['class'=>'']) !!}
@@ -172,7 +192,7 @@ Join Hackspace Manchester
 
     <div class="row">
         <div class="col-xs-12 col-md-8 col-md-offset-2 col-lg-6 col-lg-offset-3">
-            {!! Form::submit('Join Us', array('class'=>'btn btn-primary')) !!}
+            {!! Form::submit('Join Hackspace Manchester', array('class'=>'btn btn-primary')) !!}
         </div>
     </div>
 


### PR DESCRIPTION
This gives new users the option of getting their fob posted to them.
This means if they are signing up at the space, they can select "collect from space" which saves me posting them a fob.