### PR TITLE
Leaving emails, tool updates

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -7,6 +7,7 @@ use BB\Entities\Settings;
 use BB\Events\MemberGivenTrustedStatus;
 use BB\Events\MemberPhotoWasDeclined;
 use BB\Exceptions\ValidationException;
+use BB\Mailer\UserMailer;
 use BB\Validators\InductionValidator;
 
 class AccountController extends Controller
@@ -417,6 +418,10 @@ class AccountController extends Controller
         $user->setLeaving();
 
         \Notification::success('Updated status to leaving');
+
+        $userMailer = new UserMailer($user);
+        $userMailer->sendLeftMessage();
+
         return \Redirect::route('account.show', [$user->id]);
     }
 

--- a/app/Mailer/UserMailer.php
+++ b/app/Mailer/UserMailer.php
@@ -62,6 +62,20 @@ class UserMailer
     }
 
 
+    public function sendLeavingMessage()
+    {
+        $user = $this->user;
+
+        $storageBoxRepository = \App::make('BB\Repo\StorageBoxRepository');
+
+        $memberBox = $storageBoxRepository->getMemberBox($this->user->id);
+
+        \Mail::queue('emails.user-leaving', ['user'=>$user, 'memberBox'=>$memberBox], function ($message) use ($user) {
+            $message->to($user->email, $user->email)->subject('You are leaving Hackspace Manchester');
+        });
+    }
+
+
     public function sendLeftMessage()
     {
         $user = $this->user;
@@ -71,7 +85,7 @@ class UserMailer
         $memberBox = $storageBoxRepository->getMemberBox($this->user->id);
 
         \Mail::queue('emails.user-left', ['user'=>$user, 'memberBox'=>$memberBox], function ($message) use ($user) {
-            $message->to($user->email, $user->email)->subject('Sorry to see you go');
+            $message->to($user->email, $user->email)->subject('You have left Hackspace Manchester');
         });
     }
 

--- a/resources/assets/less/custom.less
+++ b/resources/assets/less/custom.less
@@ -5,6 +5,18 @@ html {
 }
 body {
   margin-bottom: 25px;
+  background: #8e9eab; /* fallback for old browsers */
+  background: -webkit-linear-gradient(
+    to bottom,
+    #eef2f3,
+    #8e9eab
+  ); /* Chrome 10-25, Safari 5.1-6 */
+  background: linear-gradient(
+    to bottom,
+    #eef2f3,
+    #8e9eab
+  ); /* W3C, IE 10+/ Edge, Firefox 16+, Chrome 26+, Opera 12+, Safari 7+ */
+  background-attachment: fixed;
 }
 .page-header {
   margin-top: 0;

--- a/resources/assets/less/mainSidenav.less
+++ b/resources/assets/less/mainSidenav.less
@@ -2,6 +2,7 @@
   border-right: 1px solid @gray-lighter;
   bottom: 0;
   background: #fff;
+  box-shadow: -10px 0 20px black;
   color: #333;
   display: block;
   left: 0;
@@ -15,7 +16,6 @@
   transition-delay: 0.1s;
   transition-duration: 0.2s;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-
   ul {
     padding: 10px 0;
   }

--- a/resources/polices/member-agreement.md
+++ b/resources/polices/member-agreement.md
@@ -1,30 +1,35 @@
 # Welcome to Hackspace Manchester!
-## This is a brief primer on how the space works
+## Here are some essentials...
 Please read and complete this induction. You will not be able to access the space until this is complete   
 
-## Introduction
+<hr/>   
 
-Hackspace Manchester is something we do together. It is a community. The infrastructure (building, equipment, tools, electric, internet etc) provides the foundations, and people working together with shared understandings and expectations are what provide a place of strong community.    
+## We have house rules
+Every member must follow the rules and guidelines in place to ensure that we continue to have an inclusive and welcoming community which can exist safely and cohesively.
 
-Every member is a citizen of the Hackspace Community and as such must follow the rules and guidelines in place to ensure that the community can exist safely and cohesively.
+Usually things work well, but when they don't we have rules in place.
 
-## House Rules
-Usually things work well, and this is in part due to our rules. 
-They can be read at any time at [here](https://hacman.org.uk/rules).
+➡️ The rules can be read at any time [here](https://hacman.org.uk/rules).
 
-## Member Handbook
-To keep things simple and provide an overview of how the space works, we have a member handbook which you can flick through. 
+## We have a member handbook
+We have a member handbook which provides a brief overview of the key aspects of a functioning hackerspace.
 
-[There is a copy online](https://list.hacman.org.uk/uploads/short-url/sytcpF9wevLdlb8VjpruXOhvrlD.pdf) and there are two copies in the space for reference:
+➡️ [There is a copy online](https://list.hacman.org.uk/t/member-handbook/2890/1) and there are two copies in the space for reference:
 * One is by the lightswitches as you come in
 * The other is on the member noticeboard.
 
-*** Please take a moment to flick through the member handbook so you're grounded in how the space operates ***
+**Please take a moment to flick through the member handbook so you're grounded in how the space operates**
 
 ## RFID Access
+When you signed up you'll have selected to either have your fob posted to you, or to collect it.
+
+### Postal fob
 When you fill in your payment information, you'll be posted a fob and a welcome flyer. The fob grants you 24/7 access to the space.
 This flyer will have the ID of the enclosed fob written on it, usually something like:
 `ABCDEF12` or `AB12CD34`. The fob ID will be made up of numbers `0-9`, and letters `A-F`. 
+
+### Collection
+On the signup desk as you come in, you'll find a holder of fobs and a welcome leaflet. Choose a fob, then follow the instructions to add the fob to your account. Your fob will start working once your first payment has gone through.
 
 You'll need to enter this ID into the membership system in order to link the fob to your account. This is easy - when it arrives:
 * Click "Your Membership" in the left hand menu
@@ -32,44 +37,57 @@ You'll need to enter this ID into the membership system in order to link the fob
 * Enter your key fob ID in the "Key Fob" section 
 * Click save.
 
-*** Please note: your Fob Will Not Work Until you have completed this induction and ticked the box at the bottom ***
+**Please note: your fob will not work until you have completed this induction, and your first payment has gone through.**
 
-## Equipment Inductions
+## Some equipment needs an induction
 
-Inductions are required for various machines around the space including:
+Inductions are mandatory for the more dangerous and expensive machines around the space.
+
+These include but are not limited to:
 * the laser cutter
 * 3D printer 
 * lathes (wood, metal)
 * CNC
 * and others... 
   
-Our inductions are run by members, and are a mixture of face to face instructions and also online through our learning platform at [https://moodle.hacman.org.uk] (https://moodle.hacman.org.uk) To access this use your member system username and password. 
+Our inductions are run by members, and are a mixture of face to face instructions and online. You can find out what tools need inductions and how to book them through the tools & equipment page here on the membership system. 
 
-For a tool eg the Laser that requires an induction you should ensure using the tools & equipment page on the members system and simply click on the tool name under the tools & equipment page. Scroll down to the section that reads " To use this piece of equipment an access fee and an induction is required. The access fee goes towards equipment maintenance"" click the Pay Now button to pay the access fee  **EVEN IF THE ACCESS FEE IS £0 you must click the pay now button for the system to register you as requiring an induction**
+To book an induction click on the tool name under the tools & equipment page. You may need to pay an induction fee as some inductions require a small expense for test materials. **If the induction cost is £0 it's free - but you must click the button for the system to register you as requiring an induction**
 
-![](https://lh3.googleusercontent.com/YHaUJkjjqv939uN9MiWgrP3TrJgp5Gvka7l1K_mAXiQhycvDqyiHSTkDeMp4nnUY5AM4Aomc8JM "induction1")
-
-![](https://lh3.googleusercontent.com/7DN9LJ8iPwCyOJcDSMfy_FYBrQdP1FBNRfwtpQF3HgtkY5XfPBBsFFn1Zdu5VxJJwlDGaWA3t6Y "laser2")
+Inductions are conducted in different ways, as stated on the tool page:
+* Some inductions are simply reading the manual, or watching some videos so you understand how to use and maintail the tool, others are done in person. 
+* Some are conducted online via Moodle at [https://moodle.hacman.org.uk] (https://moodle.hacman.org.uk) - to access this use your member system username and password. 
+* Some tools such as the Laser Cutter require an in-person induction
 
 Once you have done the above you will be enrolled onto the appropriate moodle course for the induction and you should also make contact with a trainer to arrange any required in person training this can be done via moodle or through telegram
 
+
 ## Members Storage
+Active members are permitted to store some things within a 600x400mm space. You need to claim your space on the membership system, which correlates to a physical storage area in the hackspace. 
 
-To help improve members storage the system supports the ability to claim your box (shelf/cube in our case) each cube/shelf of members storage in the space now has a laser cut number on it. This number refers to the ID number in the members storage system  
+To Claim a storage space, find a place that works for you in the hackspace, note the ID, then go to the membership system, and in the "Member Storage" page, and simply find the corresponding number and click claim.  
 
-![](https://lh3.googleusercontent.com/KRrGMgFdAB0owluDI9IoUHObaFGyFHUbA_UCEb6iEpITgD9xEW_eKJm94ftac68OQNcafHt9k2s "MembersStorage")
+If you no longer need your members storage space or you are leaving the hackspace please ensure you return the space. If not it will remain occupied until someone does a manual clearout - anything that is left after you leave may be destroyed, disposed of, moved or hacked.
 
-To Claim your space. Click on Members Storage on the left hand menu and simply find the corresponding number and click claim.  
+## Large Project Storage
+We have extremely limited space for the storage of large projects. This is detailed in the Member Handbook - but all projects stored there must be labelled appropriately with contact details, and be actively worked on.
 
-![](https://lh3.googleusercontent.com/r6QhbDfXJurMXq3g4rMf4OB_noLJEz6F7dS3VxWoyLtM-BGqgs_KPgk9z7nv_u6D8XCnvqA7do8 "memberstorage2")
+## Let's be social
+### For our group chat, join our Telegram chat
+[Click here to join the Telegram group chat](https://t.me/hacmanchester)
 
-If you no longer need your members storage space or you are leaving the hackspace please ensure you return the space by clicking the button  
-![enter image description here](https://lh3.googleusercontent.com/xzDa2RD99_prOJIPg4LsDhJE8ZK5QtnKSoYh-ZDdTCNUHjCwEmqPrnpPZkkfKHJCmj9GHokpGKA)  
-**If you are currently violating member storage rules by having more than one cube or 1/2 a shelf please ensure you rectify this as you might otherwise find your stuff is moved so members without spaces can claim a space**
+### For threaded discussions, use the Forum
+[Click here to visit the forum](https://list.hacman.org.uk)
 
-## Questions?
-If you have any questions regarding getting started as a member please use the forum, [telegram](https://t.me/hacmanchester) chat or directly email the board on board@hacman.org.uk 
+### We have social media
+* [Instagram](https://www.instagram.com/hacmanchester) 
+* [Facebook](facebook.com/hacmanchester)
+* [Twitter](twitter.com/hacmanchester)
+  
+## For business issues, problems with other members, or other "big" stuff - contact the board
+You can directly email the board at board@hacman.org.uk 
 
 
-## We look forward to seeing you soon!
+# We look forward to seeing you soon!
+Now you have completed the induction, please confirm you have understood its contents:
 

--- a/resources/views/account/induction/show.blade.php
+++ b/resources/views/account/induction/show.blade.php
@@ -15,11 +15,11 @@
 
 @section('content')
 
-    <div class="col-sm-12 col-lg-8 col-sm-offset-2">
+    <div class="col-sm-12 col-lg-8 col-sm-offset-2 well">
         {!! $document !!}
     </div>
 
-    {!! Form::open(array('route' => ['account.induction.update', $user->id], 'class'=>'form-horizontal', 'method'=>'PUT')) !!}
+    {!! Form::open(array('route' => ['account.induction.update', $user->id], 'class'=>'form-horizontal well', 'method'=>'PUT')) !!}
 
     <div class="form-group {{ Notification::hasErrorDetail('induction_completed', 'has-error has-feedback') }}">
         <div class="col-sm-12 col-lg-8 col-sm-offset-2">

--- a/resources/views/account/partials/cancel-panel.blade.php
+++ b/resources/views/account/partials/cancel-panel.blade.php
@@ -3,33 +3,34 @@
         <h3 class="panel-title">Thinking of leaving?</h3>
     </div>
     <div class="panel-body">
-        <p>
-        If you're thinking of leaving we would love to hear from you first, please send us a message and we will see if we can help.<br />
-        <a href="mailto:board@hacman.org.uk">Email the Board</a>
+        <p class="well">
+            <b>Did something go wrong?</b><br/>
+            If you're thinking of leaving, please send us a message and we will see what we can do. We would like to make it right if we can!<br />
+            <a class="btn btn-success" href="mailto:board@hacman.org.uk">Email the Board</a>
         </p>
         @if ($user->payment_method == 'gocardless')
 
             {!! Form::open(array('method'=>'DELETE', 'route' => ['account.subscription.destroy', $user->id, 1])) !!}
-            {!! Form::submit('Cancel Your Monthly Direct Debit', array('class'=>'btn btn-link')) !!}
+            {!! Form::submit('Cancel Your Monthly Direct Debit', array('class'=>'btn btn-danger')) !!}
             {!! Form::close() !!}
 
         @elseif ($user->payment_method == 'gocardless-variable')
 
             {!! Form::open(array('method'=>'DELETE', 'route' => ['account.subscription.destroy', $user->id, 1])) !!}
-            {!! Form::submit('Cancel Your Direct Debit and Leave', array('class'=>'btn btn-link')) !!}
+            {!! Form::submit('Cancel Your Direct Debit and Leave', array('class'=>'btn btn-danger')) !!}
             {!! Form::close() !!}
 
         @elseif ($user->payment_method == 'paypal')
 
             {!! Form::open(array('method'=>'DELETE', 'route' => ['account.destroy', $user->id])) !!}
-            {!! Form::submit('Leave Hackspace Manchester :(', array('class'=>'btn btn-link')) !!}
+            {!! Form::submit('Leave Hackspace Manchester :(', array('class'=>'btn btn-danger')) !!}
             {!! Form::close() !!}
             <p>This will <strong>NOT</strong> cancel your PayPal subscription, you need to do this yourself though the PayPal site.</p>
 
         @else
 
             {!! Form::open(array('method'=>'DELETE', 'route' => ['account.destroy', $user->id])) !!}
-            {!! Form::submit('Leave Hackspace Manchester :(', array('class'=>'btn btn-link')) !!}
+            {!! Form::submit('Leave Hackspace Manchester :(', array('class'=>'btn btn-danger')) !!}
             {!! Form::close() !!}
 
         @endif

--- a/resources/views/emails/user-leaving.blade.php
+++ b/resources/views/emails/user-leaving.blade.php
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<p>
+    Hi {{ $user['given_name'] }},<br />
+    <b>😢 You're leaving Hackspace Manchester</b><br />
+    Your membership has been cancelled, and you'll stop being a member of Hackspace Manchester at the end of the current payment cycle.<br />
+</p>
+<p>
+    <b>🙁 How come you chose to leave?</b><br/>
+    We would really appreciate if you could take 30 seconds to fill in our exit survey.<br/>
+    If something went wrong we are keen to make it right.
+    <li>Please take our exit survey: <a href="https://surveys.hacman.org.uk/index.php/735111">https://surveys.hacman.org.uk/index.php/735111</a></li>
+    <li>If something went wrong, and you'd like a response, please email the board at <a href="mailto:board@hacman.org.uk">board@hacman.org.uk</a>
+</p>
+@if ($memberBox)
+<p>
+    It looks like you have a members storage box. Please ensure you have removed all your items from it otherwise they will be disposed of to free up space for other members.
+</p>
+@endif
+<p>
+    <b>You're welcome back any time!<b><br/>
+    If you have changed your mind and wish to remain part of Hackspace Manchester you can do this by logging in anytime within the next 12 months and set up a subscription payment, after this time you will need to sign up again.<br />
+    Alternatively if you believe this has been sent in error please email <a href="mailto:board@hacman.org.uk">board@hacman.org.uk</a> with the details of your subscription payment and we will investigate.<br />
+    <a href="{{ URL::route('home') }}">Hackspace Manchester Member System</a><br/>
+</p>
+<p>
+    Thank you,<br />
+    The Hackspace Manchester board
+</p>
+
+</body>
+</html>

--- a/resources/views/emails/user-left.blade.php
+++ b/resources/views/emails/user-left.blade.php
@@ -6,6 +6,7 @@
 <body>
 <p>
     Hi {{ $user['given_name'] }},<br />
+    <b>😢 You've left Hackspace Manchester</b><br />
     Your last membership payment for Hackspace Manchester has now expired and you have been marked as having left.<br />
     We are sorry to see you go and hope you had a great time while you were here.<br />
     <br />
@@ -19,7 +20,7 @@
 @endif
 <p>
     If you have changed your mind and wish to remain part of Hackspace Manchester you can do this by logging in anytime within the next 12 months and set up a subscription payment, after this time you will need to sign up again.<br />
-    Alternatively if you believe this has been sent in error please reply with the details of your subscription payment and we will investigate.<br />
+    Alternatively if you believe this has been sent in error please email <a href="mailto:board@hacman.org.uk">board@hacman.org.uk</a> with the details of your subscription payment and we will investigate.<br />
     <a href="{{ URL::route('home') }}">Hackspace Manchester Member System</a><br/>
 </p>
 <p>

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -22,126 +22,113 @@ Tools and Equipment
 @section('content')
 
 <div class="row">
-
-    <div class="col-md-12 col-lg-12">
-        <div class="row">
-            <div class="col-md-12 col-lg-6">
-                <div class="well">
-
-                    <div class="row">
-                        <div class="col-md-12 col-lg-6">
-
-                            @if ($equipment->present()->manufacturerModel) Make: {{ $equipment->present()->manufacturerModel }}<br />@endif
-                            <!-- @if ($equipment->colour) Colour: {{ $equipment->colour }}<br />@endif -->
-                            @if ($equipment->present()->livesIn) Lives in: {{ $equipment->present()->livesIn }}<br />@endif
-                            @if ($equipment->present()->purchaseDate) Purchased: {{ $equipment->present()->purchaseDate }}<br />@endif
-                            @if ($equipment->requiresInduction()) Induction required<br /> @endif
-                            @if ($equipment->hasUsageCharge())
-                            Usage Cost: {!! $equipment->present()->usageCost() !!}<br />
-                            @endif
-                            @if ($equipment->isManagedByGroup())
-                                Managed By: <a href="{{ route('groups.show', $equipment->role->name) }}">{{ $equipment->role->title }}</a>
-                            @endif
-
-                            @if (!$equipment->isWorking())<span class="label label-danger">Out of action</span>@endif
-                            @if ($equipment->isPermaloan())<span class="label label-warning">Permaloan</span>@endif
-
-                        </div>
-                        <div class="col-md-12 col-lg-6">
-
-                        </div>
-                    </div>
-
-                    <br />
-
-                    {!! $equipment->present()->description !!}
-                    <br />
-
-                    @if ($equipment->help_text)
-                        <a data-toggle="modal" data-target="#helpModal" href="#" class="btn btn-info">Help</a>
-                        <br /><br />
+    <div class="col-sm-12 col-lg-6">
+        <div class="well">
+            <div class="row">
+                <div class="col-md-12 col-lg-6">
+                    <h2>{{ $equipment->name }}</h2>
+                    @if ($equipment->requiresInduction())<b style="color:red">⚠️ Induction required</b><br /> @endif
+                    @if ($equipment->present()->livesIn) 🏠 Lives in: {{ $equipment->present()->livesIn }}<br />@endif
+                    @if ($equipment->present()->manufacturerModel) 🔧 Make: {{ $equipment->present()->manufacturerModel }}<br />@endif
+                    @if ($equipment->present()->purchaseDate) Purchased: {{ $equipment->present()->purchaseDate }}<br />@endif
+                    @if ($equipment->hasUsageCharge())
+                        💵 Usage Cost: {!! $equipment->present()->usageCost() !!}<br />
                     @endif
-
-                    {!! $equipment->present()->ppe !!}
-
-
-                    @if ($equipment->requiresInduction())
-
-                        @if (!$userInduction)
-
-                            <p>
-                            To use this piece of equipment an access fee and an induction is required. The access fee goes towards equipment maintenance.<br />
-                            <strong>Equipment access fee: &pound{{ $equipment->access_fee }}</strong><br />
-                            </p>
-
-                            @if(Auth::user()->online_only)
-                                <h4>Online Only users may not sign up for tools</h4>
-                            @else
-                                <div class="paymentModule" data-reason="induction" data-display-reason="Equipment Access Fee" data-button-label="Pay Now" data-methods="balance" data-amount="{{ $equipment->access_fee }}" data-ref="{{ $equipment->induction_category }}"></div>
-                            @endif
-
-                        @elseif ($userInduction->is_trained)
-
-                            @if (in_array($equipment->slug, ['laser', 'laser-1', 'printer-lfp-1', '3dprint-mendel90', '3dprint-mendelmax', 'vac-former-1', 'ultimaker']))
-                            <p>
-                                While the access control systems are unavailable you can make a payment for your usage of the equipment below.
-                            </p>
-
-                            <div class="paymentModule" data-reason="equipment-fee" data-display-reason="Usage Fee" data-button-label="Pay Now" data-methods="balance" data-ref="{{ $equipment->slug }}"></div>
-                            @endif
-
-                            <span class="label label-success">You have been inducted and can use this equipment</span>
-
-                        @elseif ($userInduction)
-
-                            <span class="label label-info">Access fee paid, induction to be completed</span>
-
-                        @endif
-
+                    @if ($equipment->isManagedByGroup())
+                        🤗 Managed By: <a href="{{ route('groups.show', $equipment->role->name) }}">{{ $equipment->role->title }}</a>
                     @endif
+                    @if ($equipment->isPermaloan())<h4><span class="label label-warning">Permaloan</span></h4>@endif
+                    @if (!$equipment->isWorking())<h4><span class="label label-danger">Out of action</span></h4>@endif
 
                 </div>
             </div>
 
+            <br />
 
-            <div class="col-sm-12 col-lg-6">
+            {!! $equipment->present()->description !!}
+            <br />
 
-                @if ($equipment->hasPhoto())
-                    @for($i=0; $i < $equipment->getNumPhotos(); $i++)
-                        <img src="{{ $equipment->getPhotoUrl($i) }}" width="170" data-toggle="modal" data-target="#image{{ $i }}" style="margin:3px 1px; padding:0;" />
+            @if ($equipment->help_text)
+                <a data-toggle="modal" data-target="#helpModal" href="#" class="btn btn-info">Help</a>
+                <br /><br />
+            @endif
 
-                        <div class="modal fade" id="image{{ $i }}" tabindex="-1" role="dialog">
-                            <div class="modal-dialog modal-lg" role="document">
-                                <div class="modal-content">
-                                    <div class="modal-body">
-                                        <img src="{{ $equipment->getPhotoUrl($i) }}" width="100%" />
-                                    </div>
-                                </div>
-                            </div>
-                        </div>
-                    @endfor
-                @endif
+            {!! $equipment->present()->ppe !!}
 
-            </div>
-
-            <div class="col-sm-12 col-lg-6">
-
-                @if ($equipment->requiresInduction())
-                    <div class="row">
-                    <h4>Trainers/Maintainers</h4>
-                    <div class="list-group">
-                        @foreach($trainers as $trainer)
-                            <a href="{{ route('members.show', $trainer->user->id) }}" class="list-group-item">
-                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
-                                {{ $trainer->user->name }}
-                            </a>
-                        @endforeach
-                    </div>
-                    </div>
-                @endif
-            </div>
         </div>
     </div>
+
+
+    @if ($equipment->requiresInduction())
+    <div class="col-sm-12 col-lg-6">
+            <h2>Induction</h2>
+            @if (!$userInduction)
+                <p>
+                To use this piece of equipment an access fee and an induction is required. The access fee goes towards equipment maintenance.<br />
+                <strong>Equipment access fee: &pound{{ $equipment->access_fee }}</strong><br />
+                </p>
+
+                @if(Auth::user()->online_only)
+                    <h4>Online Only users may not sign up for tools</h4>
+                @else
+                    <div class="paymentModule" data-reason="induction" data-display-reason="Equipment Access Fee" data-button-label="{{ $equipment->access_fee == 0 ? 'Book Free Induction' : 'Pay Induction Fee' }}" data-methods="balance" data-amount="{{ $equipment->access_fee }}" data-ref="{{ $equipment->induction_category }}"></div>
+                @endif
+
+            @elseif ($userInduction->is_trained)
+                @if (in_array($equipment->slug, ['laser', 'laser-1', 'printer-lfp-1', '3dprint-mendel90', '3dprint-mendelmax', 'vac-former-1', 'ultimaker']))
+                    <h2>Pay for usage</h2>
+                    <p>
+                        While the access control systems are unavailable you can make a payment for your usage of the equipment below.
+                    </p>
+
+                    <div class="paymentModule" data-reason="equipment-fee" data-display-reason="Usage Fee" data-button-label="Pay Now" data-methods="balance" data-ref="{{ $equipment->slug }}"></div>
+                @endif
+
+                <h4>
+                    <span class="label label-success">You have been inducted and can use this equipment</span>
+                </h4>
+            @elseif ($userInduction)
+                <h4>
+                    <span class="label label-info">Access fee paid, induction to be completed</span>
+                </h4>
+            @endif
+        </div>
+    @endif
+
+    @if ($equipment->hasPhoto())
+        <div class="col-sm-12 col-md-6">
+            <h2>Photo gallery</h2>
+            @for($i=0; $i < $equipment->getNumPhotos(); $i++)
+                <img src="{{ $equipment->getPhotoUrl($i) }}" width="170" data-toggle="modal" data-target="#image{{ $i }}" style="margin:3px 1px; padding:0;" />
+
+                <div class="modal fade" id="image{{ $i }}" tabindex="-1" role="dialog">
+                    <div class="modal-dialog modal-lg" role="document">
+                        <div class="modal-content">
+                            <div class="modal-body">
+                                <img src="{{ $equipment->getPhotoUrl($i) }}" width="100%" />
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            @endfor
+        </div>
+    @endif
+
+    @if ($equipment->requiresInduction())
+        <div class="col-sm-12 col-lg-6">
+            <div class="row">
+            <h2>Trainers/Maintainers</h2>
+            <div class="list-group">
+                @foreach($trainers as $trainer)
+                    <a href="{{ route('members.show', $trainer->user->id) }}" class="list-group-item">
+                        {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
+                        {{ $trainer->user->name }}
+                    </a>
+                @endforeach
+            </div>
+            </div>
+        </div>
+    @endif
 
 
     @if ($equipment->hasActivity())


### PR DESCRIPTION
* System now emails after someone clicks leave, but before they actualy do leave. This gives time to rectify any issues before they actually head off
* User leaving box asks if something happened to encourage engagement with board before leaving
* Updates the induction and removed broken images
* Tool induction page hopefully more readable now, broken into sections with key information highlighted.