### PR TITLE
require keyfob before allowing access code

### DIFF
--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -39,7 +39,7 @@ class KeyFobController extends Controller
             throw new \BB\Exceptions\AuthenticationException();
         }
 
-        $input = \Input::only('user_id', 'key_id');
+        $input = \Input::only('key_id');
 
         //If the fob begins with ff it's a request for an access code
         //Bin off any extra characters
@@ -55,7 +55,10 @@ class KeyFobController extends Controller
 
         $this->keyFobForm->validate($input);
 
-        KeyFob::create($input);
+        KeyFob::create((
+            "user_id" => \Auth::user()->id, 
+            "key_id" => $input['key_id']
+        );
 
         \Notification::success("Key fob/Access code has been activated");
         return \Redirect::route('account.show', $input['user_id']);

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -55,7 +55,7 @@ class KeyFobController extends Controller
 
         $this->keyFobForm->validate($input);
 
-        KeyFob::create((
+        KeyFob::create(array(
             "user_id" => \Auth::user()->id, 
             "key_id" => $input['key_id']
         ));

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -55,10 +55,10 @@ class KeyFobController extends Controller
 
         $this->keyFobForm->validate($input);
 
-        KeyFob::create(array(
-            "user_id" => \Auth::user()->id, 
-            "key_id" => $input['key_id']
-        ));
+        KeyFob::create([
+            'user_id' => \Auth::user()->id, 
+            'key_id' => $input['key_id']
+        ]);
 
         \Notification::success("Key fob/Access code has been activated");
         return \Redirect::route('account.show', $input['user_id']);

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -35,16 +35,21 @@ class KeyFobController extends Controller
      */
     public function store()
     {
-        if(\Auth::user()->online_only){
+        if(\Auth::user()->online_only || !\Auth::user()->induction_completed){
             throw new \BB\Exceptions\AuthenticationException();
         }
 
         $input = \Input::only('user_id', 'key_id');
 
-        //If the fob befins with ff it's a request for an access cod
+        //If the fob begins with ff it's a request for an access code
         //Bin off any extra characters
-
         if(substr( $input['key_id'], 0, 2 ) === "ff"){
+            // Don't allow users to set up a keycode if they don't have an access method (i.e. fob)
+            if(\Auth::user()->keyFobs()->count() == 0){
+                throw new \BB\Exceptions\AuthenticationException();
+            }
+
+            // generate random access code, if there's a collision, it'll fail due to db constraints
             $input['key_id']="ff".rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9);
         }
 

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -58,7 +58,7 @@ class KeyFobController extends Controller
         KeyFob::create((
             "user_id" => \Auth::user()->id, 
             "key_id" => $input['key_id']
-        );
+        ));
 
         \Notification::success("Key fob/Access code has been activated");
         return \Redirect::route('account.show', $input['user_id']);

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -85,12 +85,12 @@ class KeyFobController extends Controller
      */
     public function destroy($id)
     {
-        $fob = KeyFob::where('id', $id);
+        $fobQuery = KeyFob::where('id', $id);
 
         if(!\Auth::user()->isAdmin()){
-            $fob->where('user_id', \Auth::user()->id);
+            $fobQuery->where('user_id', \Auth::user()->id);
         }
-        $fob->first();
+        $fob = $fobQuery->firstOrFail();
         $fob->markLost();
         \Notification::success("Key Fob marked as lost/broken");
         return \Redirect::route('account.show',$fob->user_id);

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -61,7 +61,7 @@ class KeyFobController extends Controller
         ]);
 
         \Notification::success("Key fob/Access code has been activated");
-        return \Redirect::route('account.show', $input['user_id']);
+        return \Redirect::route('account.show', \Auth::user()->id);
     }
 
 

--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -85,7 +85,12 @@ class KeyFobController extends Controller
      */
     public function destroy($id)
     {
-        $fob = KeyFob::findOrFail($id);
+        $fob = KeyFob::where('id', $id);
+
+        if(!\Auth::user()->isAdmin()){
+            $fob->where('user_id', \Auth::user()->id);
+        }
+        $fob->first();
         $fob->markLost();
         \Notification::success("Key Fob marked as lost/broken");
         return \Redirect::route('account.show',$fob->user_id);

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -229,43 +229,56 @@ Edit your details
         </div>
     </div>
 
-    <ol>
-    @foreach ($user->keyFobs()->get() as $fob)
-        {!! Form::open(array('method'=>'DELETE', 'route' => ['keyfob.destroy', $fob->id], 'class'=>'form-horizontal')) !!}
-            <li>
-                @if (substr( $fob->key_id, 0, 2 ) !== "ff")
-                    <p>
-                        <div class="badge" style="background:forestgreen">
-                        🔑 Fob
+    <h3>Your existing entry methods</h3>
+    @if ($user->keyFobs()->count() == 0)
+        <div class="panel panel-info">
+            <div class="panel-heading">No entry methods</div>
+            <div class="panel-body">
+                <p>
+                    You have no entry methods added to your account.
+                </p>
+            </div>
+        </div>
+    @else
+        <ol>
+        @foreach ($user->keyFobs()->get() as $fob)
+            {!! Form::open(array('method'=>'DELETE', 'route' => ['keyfob.destroy', $fob->id], 'class'=>'form-horizontal')) !!}
+                <li>
+                    @if (substr( $fob->key_id, 0, 2 ) !== "ff")
+                        <p>
+                            <div class="badge" style="background:forestgreen">
+                            🔑 Fob
+                            </div>
+                            <div class="badge">
+                                Fob ID: {{ $fob->key_id }}
+                            </div> 
+                            <small>(added {{ $fob->created_at->toFormattedDateString() }})</small>
+                        </p>
+                        <div class="">
+                            {!! Form::submit('Mark Fob Lost', array('class'=>'btn btn-default')) !!}
                         </div>
-                        <div class="badge">
-                            Fob ID: {{ $fob->key_id }}
-                        </div> 
-                        <small>(added {{ $fob->created_at->toFormattedDateString() }})</small>
-                    </p>
-                    <div class="">
-                        {!! Form::submit('Mark Fob Lost', array('class'=>'btn btn-default')) !!}
-                    </div>
-                @else
-                    <p>
-                        <div class="badge" style="background:tomato">
-                        🔢 Access Code
+                    @else
+                        <p>
+                            <div class="badge" style="background:tomato">
+                            🔢 Access Code
+                            </div>
+                            <div class="badge">
+                                Code: {{ str_replace('f', '', $fob->key_id) }}
+                            </div> 
+                            <small>(added {{ $fob->created_at->toFormattedDateString() }})</small>
+                        </p>
+                        <div class="">
+                            {!! Form::submit('Mark Code Lost', array('class'=>'btn btn-default')) !!}
                         </div>
-                        <div class="badge">
-                            Code: {{ str_replace('f', '', $fob->key_id) }}
-                        </div> 
-                        <small>(added {{ $fob->created_at->toFormattedDateString() }})</small>
-                    </p>
-                    <div class="">
-                        {!! Form::submit('Mark Code Lost', array('class'=>'btn btn-default')) !!}
-                    </div>
-                @endif
-            </li>
-        {!! Form::hidden('user_id', $user->id) !!}
-        {!! Form::close() !!}
-    @endforeach
-    </ol>
+                    @endif
+                </li>
+            {!! Form::hidden('user_id', $user->id) !!}
+            {!! Form::close() !!}
+        @endforeach
+        </ol>
+    @endif
 
+    <h3>Add a new entry method</h3>
     @if ($user->induction_completed)
         @if ($user->keyFobs()->count() < 2)
             <div class="row well">
@@ -305,10 +318,15 @@ Edit your details
             <p>You have added the maximum number of entry methods permitted.</p>
         @endif
     @else
-        <p>
-            You must <a href="/account/0/induction">complete your General Induction</a> before you can get physical access to the space.<br>
-            This is so you understand and agree to the rules.
-        </p>
+        <div class="panel panel-info">
+            <div class="panel-heading">You need to do your online general induction</div>
+            <div class="panel-body">
+                <p>
+                    You must <a href="/account/0/induction">complete your General Induction</a> before you can get physical access to the space.<br>
+                    This is so you understand and agree to the rules.
+                </p>
+            </div>
+        </div>
     @endif
 @else
 <div class="alert alert-danger">

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -208,7 +208,7 @@ Edit your details
 <h2 id="access">Key Fobs and Access Codes</h4>
 @if (!$user->online_only)
 
-    <div class="panel panel-warning">
+    <div class="panel panel-info">
         <div class="panel-heading">Getting into the space</b></div>
         <div class="panel-body">
             <p>
@@ -224,7 +224,7 @@ Edit your details
 
     <h3>Your existing entry methods</h3>
     @if ($user->keyFobs()->count() == 0)
-        <div class="panel panel-info">
+        <div class="panel panel-warning">
             <div class="panel-heading">No entry methods</div>
             <div class="panel-body">
                 <p>
@@ -329,7 +329,7 @@ Edit your details
             <p>You have added the maximum number of entry methods permitted.</p>
         @endif
     @else
-        <div class="panel panel-info">
+        <div class="panel panel-warning">
             <div class="panel-heading">You need to do your online general induction</div>
             <div class="panel-body">
                 <p>

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -302,7 +302,6 @@ Edit your details
                                     {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
                                 </div>
                             </div>
-                            {!! Form::hidden('user_id', $user->id) !!}
                             {!! Form::close() !!}
                         </div>
                         <div class="col-md-6">
@@ -315,7 +314,6 @@ Edit your details
                                         {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
                                     </div>
                                 </div>
-                                {!! Form::hidden('user_id', $user->id) !!}
                                 {!! Form::close() !!}
                             @else
                                 <p><b>Sorry, you need to set up a fob before you get an access code.</b><br>

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -287,15 +287,15 @@ Edit your details
                 <div class="col-md-6">
                     <h4>Request access code</h4>
                     @if($user->keyFobs()->count() > 0)
-                    {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                    <div class="form-group">
-                        <div class="col-sm-3">
-                            {!! Form::hidden('key_id', 'ff00000000') !!}
-                            {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+                        {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                        <div class="form-group">
+                            <div class="col-sm-3">
+                                {!! Form::hidden('key_id', 'ff00000000') !!}
+                                {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+                            </div>
                         </div>
-                    </div>
-                    {!! Form::hidden('user_id', $user->id) !!}
-                    {!! Form::close() !!}
+                        {!! Form::hidden('user_id', $user->id) !!}
+                        {!! Form::close() !!}
                     @else
                         <p><b>Sorry, you need to set up a fob first</b> This is so that new members meet with an existing member to set their fob up and get a general induction</p>
                     @endif

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -207,14 +207,6 @@ Edit your details
 
 <h2 id="access">Key Fobs and Access Codes</h4>
 @if (!$user->online_only)
-    @if (!$user->keyfob())
-        <div class="panel panel-info">
-            <div class="panel-heading">Adding a keyfob</div>
-            <div class="panel-body">
-                <p><b>If you are at the space signup desk</b> select the text box to add a new fob, then scan your fob with the reader. Then hit "Add new fob"</p>   
-            </div>
-        </div>
-    @endif
 
     <div class="panel panel-warning">
         <div class="panel-heading">Getting into the space</b></div>
@@ -281,6 +273,16 @@ Edit your details
 
     <h3>Add a new entry method</h3>
     @if ($user->induction_completed)
+        @if (!$user->keyfob())
+            <div class="panel panel-info">
+                <div class="panel-heading">You have no entry methods added</div>
+                <div class="panel-body">
+                    <p><b>If you are logged in on the hackspace computer</b> select the text box below, then scan your fob with the reader. The ID will be typed in.</p>   
+                    <p><b>If you are logged in on your own device</b>, open a blank text document, then scan your fob. The fob ID will be typed in. Add this to your account below.</p>   
+                </div>
+            </div>
+        @endif
+        
         @if ($user->keyFobs()->count() < 2)
             <div class="row well">
                 <div class="col-md-6">

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -275,46 +275,54 @@ Edit your details
     @if ($user->induction_completed)
         @if (!$user->keyfob())
             <div class="panel panel-info">
-                <div class="panel-heading">You have no entry methods added</div>
+                <div class="panel-heading">How to add an entry method using the membership PC</div>
                 <div class="panel-body">
-                    <p><b>If you are logged in on the hackspace computer</b> select the text box below, then scan your fob with the reader. The ID will be typed in.</p>   
-                    <p><b>If you are logged in on your own device</b>, open a blank text document, then scan your fob. The fob ID will be typed in. Add this to your account below.</p>   
+                    <p>If you are logged in to the membership system <b>on the hackspace PC</b> select the text box below, then scan your fob with the reader. The ID will be typed in.</p>   
+                    <p>If you are logged in to the membership system <b>on your own device</b>, open a blank text document, then scan your fob. The fob ID will be typed in. Add this to your account below.</p>   
                 </div>
             </div>
         @endif
         
         @if ($user->keyFobs()->count() < 2)
-            <div class="row well">
-                <div class="col-md-6">
-                    <h4>Add a Keyfob</h4>
-                    {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                    <div class="form-group">
-                        <div class="col-sm-5">
-                            {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
-                            Characters A-F and numbers 0-9 only.
-                        </div>
-                        <div class="col-sm-3">
-                            {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
-                        </div>
-                    </div>
-                    {!! Form::hidden('user_id', $user->id) !!}
-                    {!! Form::close() !!}
-                </div>
-                <div class="col-md-6">
-                    <h4>Request access code</h4>
-                    @if($user->keyFobs()->count() > 0)
-                        {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                        <div class="form-group">
-                            <div class="col-sm-3">
-                                {!! Form::hidden('key_id', 'ff00000000') !!}
-                                {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+            <div class="panel panel-success">
+                <div class="panel-heading">Add a new entry method</div>
+                <div class="panel-body">
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h4>Add a keyfob</h4>
+                            <p>Select a fob from the pot, or use a compatible 13.56Mhz fob you already have</p>
+
+                            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                            <div class="form-group">
+                                <div class="col-sm-5">
+                                    {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
+                                    Characters A-F and numbers 0-9 only.
+                                </div>
+                                <div class="col-sm-3">
+                                    {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
+                                </div>
                             </div>
+                            {!! Form::hidden('user_id', $user->id) !!}
+                            {!! Form::close() !!}
                         </div>
-                        {!! Form::hidden('user_id', $user->id) !!}
-                        {!! Form::close() !!}
-                    @else
-                        <p><b>Sorry, you need to set up a fob first</b> This is so that new members meet with an existing member to set their fob up and get a general induction</p>
-                    @endif
+                        <div class="col-md-6">
+                            <h4>Request access code</h4>
+                            @if($user->keyFobs()->count() > 0)
+                                {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                                <div class="form-group">
+                                    <div class="col-sm-3">
+                                        {!! Form::hidden('key_id', 'ff00000000') !!}
+                                        {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+                                    </div>
+                                </div>
+                                {!! Form::hidden('user_id', $user->id) !!}
+                                {!! Form::close() !!}
+                            @else
+                                <p><b>Sorry, you need to set up a fob before you get an access code.</b><br>
+                                This is so that new members meet with an existing member to set their fob up.</p>
+                            @endif
+                        </div>
+                    </div>  
                 </div>
             </div>
         @else

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -210,8 +210,7 @@ Edit your details
         <div class="panel panel-info">
             <div class="panel-heading">Adding a keyfob</div>
             <div class="panel-body">
-                <p><b>If you have your welcome flyer and fob,</b> just enter the ID on the flyer into the box below and hit "Add a new fob"
-                <p><b>If you are at the space signup desk,</b> select the text box to add a new fob, then scan your fob with the reader. Then hit "Add new fob"</p>   
+                <p><b>If you are at the space signup desk</b> select the text box to add a new fob, then scan your fob with the reader. Then hit "Add new fob"</p>   
             </div>
         </div>
     @endif
@@ -223,9 +222,9 @@ Edit your details
             Active, paid up, non-banned members have two ways to access the space:
             <ul>
                 <li>Using a fob - this is the primary method - enter the ID of the fob below to add a fob.</li>
-                <li>Using an access code - this is auto-generated and cannot be edited.</li>
+                <li>Using an access code - once you have a fob, you may generate an access code which is auto-generated and cannot be edited.</li>
             </ul>
-            Use is logged to prevent abuse of this secondary access system.
+            Use is logged to prevent abuse of the space.
             </p>
         </div>
     </div>
@@ -267,37 +266,49 @@ Edit your details
     @endforeach
     </ol>
 
-    @if ($user->keyFobs()->count() < 2)
-    <div class="row well">
-        <div class="col-md-6">
-            <h4>Add a Keyfob</h4>
-            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-            <div class="form-group">
-                <div class="col-sm-5">
-                    {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
-                    Characters A-F and numbers 0-9 only.
+    @if ($user->induction_completed)
+        @if ($user->keyFobs()->count() < 2)
+            <div class="row well">
+                <div class="col-md-6">
+                    <h4>Add a Keyfob</h4>
+                    {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                    <div class="form-group">
+                        <div class="col-sm-5">
+                            {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
+                            Characters A-F and numbers 0-9 only.
+                        </div>
+                        <div class="col-sm-3">
+                            {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
+                        </div>
+                    </div>
+                    {!! Form::hidden('user_id', $user->id) !!}
+                    {!! Form::close() !!}
                 </div>
-                <div class="col-sm-3">
-                    {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
+                <div class="col-md-6">
+                    <h4>Request access code</h4>
+                    @if($user->keyFobs()->count() > 0)
+                    {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                    <div class="form-group">
+                        <div class="col-sm-3">
+                            {!! Form::hidden('key_id', 'ff00000000') !!}
+                            {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+                        </div>
+                    </div>
+                    {!! Form::hidden('user_id', $user->id) !!}
+                    {!! Form::close() !!}
+                    @else
+                        <p><b>Sorry, you need to set up a fob first</b> This is so that new members meet with an existing member to set their fob up and get a general induction</p>
+                    @endif
                 </div>
             </div>
-            {!! Form::hidden('user_id', $user->id) !!}
-            {!! Form::close() !!}
-        </div>
-        <div class="col-md-6">
-            <h4>Request access code</h4>
-            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-            <div class="form-group">
-                <div class="col-sm-3">
-                    {!! Form::hidden('key_id', 'ff00000000') !!}
-                    {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
-                </div>
-            </div>
-            {!! Form::hidden('user_id', $user->id) !!}
-            {!! Form::close() !!}
-        </div>
-    </div>
-
+        @else
+            <p>You have added the maximum number of entry methods permitted.</p>
+        @endif
+    @else
+        <p>
+            You must <a href="/account/0/induction">complete your General Induction</a> before you can get physical access to the space.<br>
+            This is so you understand and agree to the rules.
+        </p>
     @endif
 @else
 <div class="alert alert-danger">

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -11,6 +11,7 @@ Edit your details
 @section('content')
 
 
+<h2>Your Details</h2>
 {!! Form::model($user, array('route' => ['account.update', $user->id], 'method'=>'PUT', 'files'=>true)) !!}
 
 <div class="row">
@@ -164,7 +165,7 @@ Edit your details
     </div>
 </div>
 
-<h4 id="newsletter">Newsletter Opt-In</h4>
+<h2 id="newsletter">Newsletter Opt-In</h4>
 <div class="row">
     <div class="col-xs-12 col-md-8">
         <div class="form-group {{ Notification::hasErrorDetail('newsletter', 'has-error has-feedback') }}">
@@ -204,7 +205,7 @@ Edit your details
 
 {!! Form::close() !!}
 
-<h4 id="access">Key Fobs and Access Codes</h4>
+<h2 id="access">Key Fobs and Access Codes</h4>
 @if (!$user->online_only)
     @if (!$user->keyfob())
         <div class="panel panel-info">

--- a/resources/views/account/partials/member-admin-action-bar.blade.php
+++ b/resources/views/account/partials/member-admin-action-bar.blade.php
@@ -104,21 +104,6 @@
                         {!! Form::hidden('user_id', $user->id) !!}
                         {!! Form::close() !!}
                         @endforeach
-
-                        @if ($user->keyFobs()->count() < 2)
-                            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                            <div class="form-group">
-                                <div class="col-sm-5">
-                                    {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
-                                </div>
-                                <div class="col-sm-3">
-                                    {!! Form::submit('Add a new fob', array('class'=>'btn btn-default')) !!}
-                                </div>
-                            </div>
-                            {!! Form::hidden('user_id', $user->id) !!}
-                            {!! Form::close() !!}
-                        @endif
-
                     </div>
                 
                     <!-- Panel -->


### PR DESCRIPTION
At a recent members meeting it was decided to not allow freshly joined members to setup a keycode, so that they had to interact with someone to set up a fob which acts as some sort of induction.

This change:
* Requires users to have completed the general induction online before they set up an access method
* Requires users to set up a keyfob first, by not allowing someone to setup a keycode until there's already an existing method

Caveats:
* If you're a long standing member and delete all your access methods, you will need to add a fob first
* This can be overridden by entering any old rubbish into the keyfob field, as we don't validate the ID entered. We could do a check for a valid looking pattern (hex characters only) but even then we can't know if an entered ID is garbage.
* This is a nudge and not intended to be foolproof.

### When you haven't done the induction
![image](https://user-images.githubusercontent.com/905676/195398420-d832467e-81e6-46df-9b89-60a26e39874c.png)

### When you have done the induction, but have no entry methods
![image](https://user-images.githubusercontent.com/905676/195398499-aadd2fb1-0059-42ff-9565-af9ac8c988c2.png)

