### PR TITLE
tool trainers can only edit tool page

### DIFF
--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -128,7 +128,7 @@ class EquipmentController extends Controller
 
         $isTrainerOrAdmin = $this
             ->inductionRepository
-            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin()
+            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin();
 
         // Get info from the docs system
         $docs ='';
@@ -227,7 +227,7 @@ class EquipmentController extends Controller
 
         $isTrainerOrAdmin = $this
             ->inductionRepository
-            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin()
+            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin();
 
         
         return \View::make('equipment.edit')

--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -220,12 +220,17 @@ class EquipmentController extends Controller
         $memberList = $this->userRepository->getAllAsDropdown();
         $roleList = \BB\Entities\Role::lists('title', 'id');
 
+        $isTrainer = Induction::where('user_id', \Auth::user()->id)
+            ->where('key', $equipment->induction_category)
+            ->where('is_trainer', 1)
+            ->count() > 0;
+        
         return \View::make('equipment.edit')
             ->with('equipment', $equipment)
             ->with('memberList', $memberList)
             ->with('roleList', $roleList->toArray())
             ->with('ppeList', $this->ppeList)
-            ->with('trusted', \Auth::user()->trusted || \Auth::user()->isAdmin());
+            ->with('isTrainer', $isTrainer || \Auth::user()->isAdmin());
     }
 
 

--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -126,6 +126,10 @@ class EquipmentController extends Controller
 
         $memberList = $this->userRepository->getAllAsDropdown();
 
+        $isTrainerOrAdmin = $this
+            ->inductionRepository
+            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin()
+
         // Get info from the docs system
         $docs ='';
         if($equipment->docs){
@@ -149,6 +153,7 @@ class EquipmentController extends Controller
             ->with('usersPendingInduction', $usersPendingInduction)
             ->with('usageTimes', $usageTimes)
             ->with('user', $user)
+            ->with('isTrainerOrAdmin', $isTrainerOrAdmin)
             ->with('memberList', $memberList)
             ->with('docs', $docs);
     }
@@ -220,17 +225,17 @@ class EquipmentController extends Controller
         $memberList = $this->userRepository->getAllAsDropdown();
         $roleList = \BB\Entities\Role::lists('title', 'id');
 
-        $isTrainer = Induction::where('user_id', \Auth::user()->id)
-            ->where('key', $equipment->induction_category)
-            ->where('is_trainer', 1)
-            ->count() > 0;
+        $isTrainerOrAdmin = $this
+            ->inductionRepository
+            ->isTrainerForEquipment($equipment->induction_category) || \Auth::user()->isAdmin()
+
         
         return \View::make('equipment.edit')
             ->with('equipment', $equipment)
             ->with('memberList', $memberList)
             ->with('roleList', $roleList->toArray())
             ->with('ppeList', $this->ppeList)
-            ->with('isTrainer', $isTrainer || \Auth::user()->isAdmin());
+            ->with('isTrainerOrAdmin', $isTrainerOrAdmin);
     }
 
 

--- a/app/Repo/InductionRepository.php
+++ b/app/Repo/InductionRepository.php
@@ -44,6 +44,16 @@ class InductionRepository extends DBRepository
         });
     }
 
+    /**
+     * @param $userID
+     * @return bool
+     */
+    public function isTrainerForEquipment($deviceId){
+        return $this->model->where('user_id', \Auth::user()->id)
+            ->where('key', $deviceId)
+            ->where('is_trainer', 1)
+            ->count() > 0;
+    }
 
     /**
      * Get all the users who have been trained on a piece of equipment

--- a/resources/views/equipment/form.blade.php
+++ b/resources/views/equipment/form.blade.php
@@ -1,6 +1,6 @@
 @section('trustLevel')
     <div class="alert alert-warning">
-        🔒 Sensitive information may be contained and can only be edited by trusted members or admins.<br/>
+        🔒 Some information may only be edited by trainers of this tool or admins.<br/>
     </div>
 @stop
 <div class="form-group {{ Notification::hasErrorDetail('name', 'has-error has-feedback') }}">
@@ -158,15 +158,15 @@
 
 <h4>Health, Safety, Training and Inductions</h4>
 <div class="alert alert-info">
-    To maintain the integrity of H&S and the training system, only admins and trusted members can edit this section.<br/>
-    <b>{{ $trusted ? "✔️ You can read/write the fields in this area" : "🔒 The fields in this area can not be edited at the moment"}}</b>
+    To maintain the integrity of H&S and the training system, only admins and trainers can edit this section.<br/>
+    <b>{{ $isTrainer ? "✔️ You can read/write the fields in this area" : "🔒 The fields in this area can not be edited at the moment"}}</b>
 </div>
 <hr/>
 
 <div class="form-group alert-danger {{ Notification::hasErrorDetail('dangerous', 'has-error has-feedback') }}">
     {!! Form::label('dangerous', 'Is Bloody Dangerous?', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::select('dangerous', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $trusted ? "" : "disabled"]) !!}
+        {!! Form::select('dangerous', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
         {!! Notification::getErrorDetail('dangerous') !!}
     </div>
 </div>
@@ -174,7 +174,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('requires_induction', 'has-error has-feedback') }}">
     {!! Form::label('requires_induction', 'Requires Induction', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::select('requires_induction', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $trusted ? "" : "disabled"]) !!}
+        {!! Form::select('requires_induction', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
         {!! Notification::getErrorDetail('requires_induction') !!}
     </div>
 </div>
@@ -182,7 +182,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('induction_category', 'has-error has-feedback') }}">
     {!! Form::label('induction_category', 'Induction Category', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::text('induction_category', null, ['class'=>'form-control', $trusted ? "" : "disabled"]) !!}
+        {!! Form::text('induction_category', null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
         <p class="help-block">By getting inducted on this piece of equipment they are inducted to this category meaning they have access to any other piece of equipment in the same category. i.e. access to all 3D Printers.</p>
         {!! Notification::getErrorDetail('induction_category') !!}
     </div>
@@ -193,7 +193,7 @@
     <div class="col-sm-9 col-lg-7">
         <div class="input-group">
             <div class="input-group-addon">&pound;</div>
-            {!! Form::input('number', 'access_fee', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'1', $trusted ? "" : "disabled"]) !!}
+            {!! Form::input('number', 'access_fee', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'1', $isTrainer ? "" : "disabled"]) !!}
         </div>
         <p class="help-block">Is an access fee being charged?</p>
         {!! Notification::getErrorDetail('access_fee') !!}
@@ -205,9 +205,9 @@
     <div class="col-sm-9 col-lg-7">
         <div class="input-group">
             <div class="input-group-addon">&pound;</div>
-            {!! Form::input('number', 'usage_cost', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'0.01', $trusted ? "" : "disabled"]) !!}
+            {!! Form::input('number', 'usage_cost', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'0.01', $isTrainer ? "" : "disabled"]) !!}
             <div class="input-group-addon">
-            Per {!! Form::select('usage_cost_per', [''=>'-', 'hour'=>'hour', 'gram'=>'gram', 'page'=>'page', $trusted ? "" : "disabled"], null, ['class'=>'']) !!}
+            Per {!! Form::select('usage_cost_per', [''=>'-', 'hour'=>'hour', 'gram'=>'gram', 'page'=>'page', $isTrainer ? "" : "disabled"], null, ['class'=>'']) !!}
             </div>
         </div>
         <p class="help-block">Does the equipment cost anything to use?</p>
@@ -218,7 +218,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('induction_instructions', 'has-error has-feedback') }}">
     {!! Form::label('induction_instructions', 'Induction Instructions', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $trusted ? Form::textarea('induction_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
+        {!! $isTrainer ? Form::textarea('induction_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
         <p class="help-block">Instructions on what to do once an induction is requested. e.g. visit a telegram group.</p>
         {!! Notification::getErrorDetail('induction_instructions') !!}
     </div>
@@ -227,7 +227,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('trained_instructions', 'has-error has-feedback') }}">
     {!! Form::label('trained_instructions', 'Trained Instructions', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $trusted ? Form::textarea('trained_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
+        {!! $isTrainer ? Form::textarea('trained_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Instructions for trained users - such as reminders or access codes</p>
         {!! Notification::getErrorDetail('trained_instructions') !!}
     </div>
@@ -236,7 +236,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('trainer_instructions', 'has-error has-feedback') }}">
     {!! Form::label('trainer_instructions', 'Instructions for Trainers', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $trusted ? Form::textarea('trainer_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
+        {!! $isTrainer ? Form::textarea('trainer_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Only trainers see this - e.g. documents to risk assessments</p>
         {!! Notification::getErrorDetail('trainer_instructions') !!}
     </div>

--- a/resources/views/equipment/form.blade.php
+++ b/resources/views/equipment/form.blade.php
@@ -159,14 +159,14 @@
 <h4>Health, Safety, Training and Inductions</h4>
 <div class="alert alert-info">
     To maintain the integrity of H&S and the training system, only admins and trainers can edit this section.<br/>
-    <b>{{ $isTrainer ? "✔️ You can read/write the fields in this area" : "🔒 The fields in this area can not be edited at the moment"}}</b>
+    <b>{{ $isTrainerOrAdmin ? "✔️ You can read/write the fields in this area" : "🔒 The fields in this area can not be edited at the moment"}}</b>
 </div>
 <hr/>
 
 <div class="form-group alert-danger {{ Notification::hasErrorDetail('dangerous', 'has-error has-feedback') }}">
     {!! Form::label('dangerous', 'Is Bloody Dangerous?', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::select('dangerous', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
+        {!! Form::select('dangerous', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainerOrAdmin ? "" : "disabled"]) !!}
         {!! Notification::getErrorDetail('dangerous') !!}
     </div>
 </div>
@@ -174,7 +174,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('requires_induction', 'has-error has-feedback') }}">
     {!! Form::label('requires_induction', 'Requires Induction', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::select('requires_induction', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
+        {!! Form::select('requires_induction', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control', $isTrainerOrAdmin ? "" : "disabled"]) !!}
         {!! Notification::getErrorDetail('requires_induction') !!}
     </div>
 </div>
@@ -182,7 +182,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('induction_category', 'has-error has-feedback') }}">
     {!! Form::label('induction_category', 'Induction Category', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! Form::text('induction_category', null, ['class'=>'form-control', $isTrainer ? "" : "disabled"]) !!}
+        {!! Form::text('induction_category', null, ['class'=>'form-control', $isTrainerOrAdmin ? "" : "disabled"]) !!}
         <p class="help-block">By getting inducted on this piece of equipment they are inducted to this category meaning they have access to any other piece of equipment in the same category. i.e. access to all 3D Printers.</p>
         {!! Notification::getErrorDetail('induction_category') !!}
     </div>
@@ -193,7 +193,7 @@
     <div class="col-sm-9 col-lg-7">
         <div class="input-group">
             <div class="input-group-addon">&pound;</div>
-            {!! Form::input('number', 'access_fee', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'1', $isTrainer ? "" : "disabled"]) !!}
+            {!! Form::input('number', 'access_fee', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'1', $isTrainerOrAdmin ? "" : "disabled"]) !!}
         </div>
         <p class="help-block">Is an access fee being charged?</p>
         {!! Notification::getErrorDetail('access_fee') !!}
@@ -205,9 +205,9 @@
     <div class="col-sm-9 col-lg-7">
         <div class="input-group">
             <div class="input-group-addon">&pound;</div>
-            {!! Form::input('number', 'usage_cost', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'0.01', $isTrainer ? "" : "disabled"]) !!}
+            {!! Form::input('number', 'usage_cost', null, ['class'=>'form-control', 'min'=>'0', 'step'=>'0.01', $isTrainerOrAdmin ? "" : "disabled"]) !!}
             <div class="input-group-addon">
-            Per {!! Form::select('usage_cost_per', [''=>'-', 'hour'=>'hour', 'gram'=>'gram', 'page'=>'page', $isTrainer ? "" : "disabled"], null, ['class'=>'']) !!}
+            Per {!! Form::select('usage_cost_per', [''=>'-', 'hour'=>'hour', 'gram'=>'gram', 'page'=>'page', $isTrainerOrAdmin ? "" : "disabled"], null, ['class'=>'']) !!}
             </div>
         </div>
         <p class="help-block">Does the equipment cost anything to use?</p>
@@ -218,7 +218,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('induction_instructions', 'has-error has-feedback') }}">
     {!! Form::label('induction_instructions', 'Induction Instructions', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $isTrainer ? Form::textarea('induction_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
+        {!! $isTrainerOrAdmin ? Form::textarea('induction_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
         <p class="help-block">Instructions on what to do once an induction is requested. e.g. visit a telegram group.</p>
         {!! Notification::getErrorDetail('induction_instructions') !!}
     </div>
@@ -227,7 +227,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('trained_instructions', 'has-error has-feedback') }}">
     {!! Form::label('trained_instructions', 'Trained Instructions', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $isTrainer ? Form::textarea('trained_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
+        {!! $isTrainerOrAdmin ? Form::textarea('trained_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Instructions for trained users - such as reminders or access codes</p>
         {!! Notification::getErrorDetail('trained_instructions') !!}
     </div>
@@ -236,7 +236,7 @@
 <div class="form-group {{ Notification::hasErrorDetail('trainer_instructions', 'has-error has-feedback') }}">
     {!! Form::label('trainer_instructions', 'Instructions for Trainers', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
-        {!! $isTrainer ? Form::textarea('trainer_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
+        {!! $isTrainerOrAdmin ? Form::textarea('trainer_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Only trainers see this - e.g. documents to risk assessments</p>
         {!! Notification::getErrorDetail('trainer_instructions') !!}
     </div>

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -175,7 +175,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
                         </a>
                         {{ $trainer->user->name }}
-                        @if (Auth::user()->isAdmin() || Auth::user()->trusted)
+                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainer->user->id, $trainer->id])) !!}
                             {!! Form::hidden('not_trainer', '1') !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -200,7 +200,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
                             {{ $trainedUser->user->name }}
                         </a>
-                        @if (Auth::user()->isAdmin() || Auth::user()->trusted)
+                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
                             {!! Form::hidden('mark_untrained', '1') !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -229,7 +229,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
                             {{ $trainedUser->user->name }}
                         </a>
-                        @if (Auth::user()->isAdmin() || Auth::user()->trusted)
+                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
                             {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -244,7 +244,7 @@ Tools and Equipment
                         @endif
                     </div>
                 @endforeach
-                @if (Auth::user()->isAdmin() || Auth::user()->trusted)
+                @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
                     <div class="list-group-item">
                         <p>Add a member</p>
                         {!! Form::open(array('method'=>'POST', 'route' => ['equipment_training.create'])) !!}

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -175,7 +175,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
                         </a>
                         {{ $trainer->user->name }}
-                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
+                        @if ($isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainer->user->id, $trainer->id])) !!}
                             {!! Form::hidden('not_trainer', '1') !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -200,7 +200,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
                             {{ $trainedUser->user->name }}
                         </a>
-                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
+                        @if ($isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
                             {!! Form::hidden('mark_untrained', '1') !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -229,7 +229,7 @@ Tools and Equipment
                             {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
                             {{ $trainedUser->user->name }}
                         </a>
-                        @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
+                        @if ($isTrainerOrAdmin)
                             {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
                             {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
@@ -244,7 +244,7 @@ Tools and Equipment
                         @endif
                     </div>
                 @endforeach
-                @if (Auth::user()->isAdmin() || $isTrainerOrAdmin)
+                @if ($isTrainerOrAdmin)
                     <div class="list-group-item">
                         <p>Add a member</p>
                         {!! Form::open(array('method'=>'POST', 'route' => ['equipment_training.create'])) !!}


### PR DESCRIPTION
When it comes to access codes for locks on super dangerous tools, we store these on the equipment page. But not everyone should be able to just edit a page to see the lock code. Therefore we got by with only letting "trusted" members view and edit these in the membership system. But as more and more people needed this trusted status, which has wider implications in the membership system, it's clear we need to have a proper fix for this.

This PR means that only people marked as trainers/maintainers for a tool (and admins) will be able to edit the access code. This means that trusted status, which allows a more broader scope of access, doesn't need to be used outside of the original scope.