### PR TITLE
make signup payment text minimum fifteen pounds

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -479,10 +479,10 @@ class AccountController extends Controller
     {
         $amount = \Input::get('monthly_subscription');
 
-        if ($amount < 12.50) {
-            throw new ValidationException('The minimum subscription is 12.50 GBP');
-        } elseif (!\Auth::user()->isAdmin() && ($amount < 12.50)) {
-            throw new ValidationException('The minimum subscription is 12.50 GBP, please contact the board for a lower amount. board@hacman.org.uk');
+        if ($amount < 15.00) {
+            throw new ValidationException('The minimum subscription is 15.00 GBP');
+        } elseif (!\Auth::user()->isAdmin() && ($amount < 15.00)) {
+            throw new ValidationException('The minimum subscription is 15.00 GBP, please contact the board for a lower amount. board@hacman.org.uk');
         }
 
         $user = User::findWithPermission($id);

--- a/resources/views/account/create.blade.php
+++ b/resources/views/account/create.blade.php
@@ -165,7 +165,7 @@ Join Hackspace Manchester
         @else
         <ul>
             <li>£20 a month, like a cheap gym membership, is the recommended amount for new starters.</li>
-            <li>You can pay less, perhaps if you're on lower income.</li>
+            <li>You can pay less, perhaps if you're on lower income, but we do ask for a minimum of £15. Click the link above for more advice.</li>
             <li>You can pay more (£25-£50) if you'd like to support the space.</li>
         </ul>
         @endif
@@ -269,12 +269,12 @@ Join Hackspace Manchester
             <div class="modal-body">
                 <p>If you're not sure how much to pay, here are some general guidelines to help you find a suitable subscription amount for your circumstances:</p>
 
-                &pound;12.50 - &pound;15 a month:
+                Minimum &pound;15 a month:
                 <ul>
                     <li>You are on a low income and unable to afford a higher amount.</li>
                 </ul>
 
-                &pound;15 - &pound;20 a month:
+                &pound;20 a month:
                 <ul>
                     <li>You are planning to visit the makerspace regularly and are a professional / in full-time employment</li>
                 </ul>
@@ -290,7 +290,7 @@ Join Hackspace Manchester
                 </p>
 
                 <p>
-                    If you would like to pay less than &pound;12.50 a month please select an amount over £12.50 and complete
+                    If you would like to pay less than &pound;15 a month please select an amount over £15 and complete
                     this form, on the next page you will be asked to setup a subscription payment.
                     Before you do this please send the board an email letting them know how much you would like to
                     pay, they will then override the amount so you can continue to setup a subscription.

--- a/resources/views/account/create.blade.php
+++ b/resources/views/account/create.blade.php
@@ -290,7 +290,7 @@ Join Hackspace Manchester
                 </p>
 
                 <p>
-                    If you would like to pay less than &pound;15 a month please select an amount over £15 and complete
+                    If you would like to pay less than &pound;15 a month please select an amount over &pound;15 and complete
                     this form, on the next page you will be asked to setup a subscription payment.
                     Before you do this please send the board an email letting them know how much you would like to
                     pay, they will then override the amount so you can continue to setup a subscription.

--- a/resources/views/account/create.blade.php
+++ b/resources/views/account/create.blade.php
@@ -164,9 +164,9 @@ Join Hackspace Manchester
         </ul>
         @else
         <ul>
-            <li>£20 a month, like a cheap gym membership, is the recommended amount for new starters.</li>
-            <li>You can pay less, perhaps if you're on lower income, but we do ask for a minimum of £15. Click the link above for more advice.</li>
-            <li>You can pay more (£25-£50) if you'd like to support the space.</li>
+            <li>&pound;20 a month, like a cheap gym membership, is the recommended amount for new starters.</li>
+            <li>You can pay less, perhaps if you're on lower income, but we do ask for a minimum of &pound;15. Click the link above for more advice.</li>
+            <li>You can pay more (&pound;25-&pound;50) if you'd like to support the space.</li>
         </ul>
         @endif
     </div>


### PR DESCRIPTION
The board has decided to raise the minimum amount we ask for new sign ups to pay £15. Of course, people are still able to input a lower amount (even lower than £12.50) but this requires a longer discussion around code changes. I have however amended the text in the sign up to reflect that we are asking people this, so as to avoid having people join now and then ask them in 2, 3 (or n months) to raise it to £15. AFAIK emails have been sent to members paying below £15 (and who are active in the space) about raising their subscription.