### PR TITLE
Fix LaravelIdeHelper breaking live

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -35,7 +35,15 @@ class AppServiceProvider extends ServiceProvider {
 		);
 		
 		if ($this->app->isLocal()) {
-			$this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
+			/**
+			 * This was breaking live (:
+			 * 
+			 * TODO: Properly re-install ide-helper as per 2.4.2 instructions (last compatible with Laravel 5.1)
+			 * @see https://github.com/barryvdh/laravel-ide-helper/tree/v2.4.3#install
+			 * 
+			 * Will also need a composer install on live, which hasn't been done in a while. Need to carefully plan.
+			 */
+			// $this->app->register(\Barryvdh\LaravelIdeHelper\IdeHelperServiceProvider::class);
 		}
 
 	}


### PR DESCRIPTION
I installed [barryvdh/laravel-ide-helper](https://github.com/barryvdh/laravel-ide-helper/) as a dev dependency, using their latest release's instructions as reference – although they didn't directly apply as we're running an older version of Laravel.

The way I then referenced the IdeHelperServiceProvider in our AppServiceProvider was then making Composer try to find a dependency that did not exist on live, for 2 reasons: Because it was a dev dependency, but also because we aren't currently running `composer install` on live (even if we installed it properly the same issue might have occurred).

My quick fix on the server was commenting out this line. This PR just formalises that change in version control, to keep this repository in sync with what's happening on live.

Separately, we should look into:

1. Carefully planning a re-deployment of the app in a new folder
    1. Ensuring permissions are all set up correctly
    2. Running `composer install`
    3. (keeping the old folder around in case we have to recover to it, due to either of the above breaking live)
2. Reinstalling laravel-ide-helper, following the relevant version's instructions: https://github.com/barryvdh/laravel-ide-helper/tree/v2.4.3#install
I'll create an issue for this :)