### PR TITLE
remove immediate activation

### DIFF
--- a/app/Repo/UserRepository.php
+++ b/app/Repo/UserRepository.php
@@ -202,7 +202,6 @@ class UserRepository extends DBRepository
         //user needs to have a recent sub charge and one that was paid or is due
 
         $user->active = true;
-        $user->status = 'active';
         $user->save();
 
         $outstandingCharges = $this->subscriptionChargeRepository->hasOutstandingCharges($userId);


### PR DESCRIPTION
**DRAFT**

### 1
At present, once a member sets up a direct debit with GoCardless and is returned back to the membership system, they're marked immediately as active. This means they can access the space from the get-go before their first payment is taken.

This PR aims to change this, so that users can only get access to the space after their first payment has been taken. This is how it used to work, and the change was due to the new membership system. 

This doesn't appear to have been abused yet, and people have appreciated immediately being able to get started, but we probably should change this.

### 2
Appears that the SQL for the door relies on the User's status being "active" or "leaving", but the website displays access to the space depending on whether User.active is 1 or not.
