### PR TITLE
Config for membership prices

### DIFF
--- a/app/Helpers/MembershipPayments.php
+++ b/app/Helpers/MembershipPayments.php
@@ -103,6 +103,6 @@ class MembershipPayments
      */
     public static function formatPrice(int $pence)
     {
-        return "£" . number_format($pence / 100, 2, ',');
+        return "£" . number_format($pence / 100, 2);
     }
 } 

--- a/app/Helpers/MembershipPayments.php
+++ b/app/Helpers/MembershipPayments.php
@@ -74,4 +74,35 @@ class MembershipPayments
             return $otherCutoff;
         }
     }
+
+    /**
+     * The minimum price for a membership to the space
+     *
+     * @return int Price in pence
+     */
+    public static function getMinimumPrice()
+    {
+        return config('membership.prices.minimum');
+    }
+
+    /**
+     * The recommended price for a membership to the space
+     *
+     * @return int Price in pence
+     */
+    public static function getRecommendedPrice()
+    {
+        return config('membership.prices.recommended');
+    }
+
+    /**
+     * Format membership prices for consistent display across the website
+     *
+     * @param integer $pence
+     * @return string
+     */
+    public static function formatPrice(int $pence)
+    {
+        return "£" . number_format($pence / 100, 2, ',');
+    }
 } 

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -158,13 +158,21 @@ class AccountController extends Controller
         }
 
 
+        $minAmount = MembershipPayments::getMinimumPrice();
+        $recommendedAmount = MembershipPayments::getRecommendedPrice();
+
+        $confetti = $gift ? $gift_valid : true;
+
         \View::share('body_class', 'register_login');
-        return \View::make('account.create')
-            ->with('gift', $gift)
-            ->with('gift_code', $gift_code)
-            ->with('gift_valid', $gift_valid)
-            ->with('gift_details', $gift_details)
-            ->with('confetti', $gift ? $gift_valid : true );
+        return \View::make('account.create', compact(
+            'minAmount',
+            'recommendedAmount',
+            'gift',
+            'gift_code',
+            'gift_valid',
+            'gift_details',
+            'confetti'
+        ));
     }
 
     /**
@@ -482,12 +490,12 @@ class AccountController extends Controller
 
         $minAmountPence = MembershipPayments::getMinimumPrice();
         $formattedMinAmount = MembershipPayments::formatPrice($minAmountPence);
-        $minAmount = $minAmountPence / 100;
+        $minAmountPounds = $minAmountPence / 100;
 
         // TODO: Lift this into some sort of "contact" config?
         $boardEmail = 'board@hacman.org.uk';
 
-        if ($amount < $minAmount) {
+        if ($amount < $minAmountPounds) {
             throw new ValidationException(sprintf('The minimum subscription is %s, please contact the board for a lower amount. %s', $formattedMinAmount, $boardEmail));
         }
 

--- a/app/Validators/UserValidator.php
+++ b/app/Validators/UserValidator.php
@@ -1,5 +1,7 @@
 <?php namespace BB\Validators;
 
+use BB\Helpers\MembershipPayments;
+
 class UserValidator extends FormValidator
 {
 
@@ -23,7 +25,7 @@ class UserValidator extends FormValidator
         'address.line_3'        => '',
         'address.line_4'        => '',
         'address.postcode'      => 'required_if:online_only,0|postcode',
-        'monthly_subscription'  => 'required_if:online_only,0|integer|min:15',
+        'monthly_subscription'  => 'required_if:online_only,0|integer', // Min will be added in getValidationRules
         'emergency_contact'     => 'required_if:online_only,0',
         'rules_agreed'          => 'accepted',
     
@@ -47,4 +49,16 @@ class UserValidator extends FormValidator
         'phone'             => '',
     ];
 
+
+    protected function getValidationRules(array $replacements = []) {
+        $rules = parent::getValidationRules($replacements);
+
+        // Set minimum monthly subscription, being careful not to apply to updates
+        if (!empty($rules['monthly_subscription'])) {
+            $minPrice = intval(MembershipPayments::getMinimumPrice() / 100);
+            $rules['monthly_subscription'] .= '|min:' . $minPrice;
+        }
+
+        return $rules;
+    }
 } 

--- a/config/app.php
+++ b/config/app.php
@@ -215,6 +215,7 @@ return [
         'Image'        => 'Intervention\Image\Facades\Image',
         'Slack'        => 'Maknz\Slack\Facades\Slack',
 
+		'MembershipPayments' => 'BB\Helpers\MembershipPayments',
     ],
 
 ];

--- a/config/app.php
+++ b/config/app.php
@@ -115,7 +115,7 @@ return [
 		 */
 		'Illuminate\Foundation\Providers\ArtisanServiceProvider',
 		'Illuminate\Auth\AuthServiceProvider',
-        Illuminate\Broadcasting\BroadcastServiceProvider::class,
+        	Illuminate\Broadcasting\BroadcastServiceProvider::class,
 		'Illuminate\Bus\BusServiceProvider',
 		'Illuminate\Cache\CacheServiceProvider',
 		'Illuminate\Foundation\Providers\ConsoleSupportServiceProvider',
@@ -136,7 +136,7 @@ return [
 		'Illuminate\Translation\TranslationServiceProvider',
 		'Illuminate\Validation\ValidationServiceProvider',
 		'Illuminate\View\ViewServiceProvider',
-        'Illuminate\Html\HtmlServiceProvider',
+        	'Illuminate\Html\HtmlServiceProvider',
 
 		/*
 		 * Application Service Providers...
@@ -154,11 +154,11 @@ return [
 	        /*
 		 * 3rd Party Providers...
 		 */
-        'Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider',
-        'Jenssegers\Rollbar\RollbarServiceProvider',
-        'Maknz\Slack\SlackServiceProvider',
-        'Intervention\Image\ImageServiceProvider',
-        ArthurGuy\Notifications\NotificationServiceProvider::class,
+        	'Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider',
+        	'Jenssegers\Rollbar\RollbarServiceProvider',
+       		'Maknz\Slack\SlackServiceProvider',
+        	'Intervention\Image\ImageServiceProvider',
+        	ArthurGuy\Notifications\NotificationServiceProvider::class,
 		Clockwork\Support\Laravel\ClockworkServiceProvider::class,
 
 	],

--- a/config/app.php
+++ b/config/app.php
@@ -143,16 +143,15 @@ return [
 		 */
 		'BB\Providers\AppServiceProvider',
 		'BB\Providers\BusServiceProvider',
-        'BB\Providers\ConfigServiceProvider',
-        'BB\Providers\EventServiceProvider',
-        'BB\Providers\RouteServiceProvider',
-        'BB\Providers\StripeServiceProvider',
-        'BB\Providers\ValidatorServiceProvider',
-        'BB\Providers\HtmlServiceProvider',
-        \BB\Providers\ObserverServiceProvider::class,
+        	'BB\Providers\ConfigServiceProvider',
+        	'BB\Providers\EventServiceProvider',
+        	'BB\Providers\RouteServiceProvider',
+        	'BB\Providers\StripeServiceProvider',
+        	'BB\Providers\ValidatorServiceProvider',
+        	'BB\Providers\HtmlServiceProvider',
+        	\BB\Providers\ObserverServiceProvider::class,
 
-
-        /*
+	        /*
 		 * 3rd Party Providers...
 		 */
         'Rap2hpoutre\LaravelLogViewer\LaravelLogViewerServiceProvider',
@@ -214,8 +213,7 @@ return [
         'Notification' => \ArthurGuy\Notifications\NotificationFacade::class,
         'Image'        => 'Intervention\Image\Facades\Image',
         'Slack'        => 'Maknz\Slack\Facades\Slack',
-
-		'MembershipPayments' => 'BB\Helpers\MembershipPayments',
+	'MembershipPayments' => 'BB\Helpers\MembershipPayments',
     ],
 
 ];

--- a/config/membership.php
+++ b/config/membership.php
@@ -1,0 +1,11 @@
+<?php
+
+return [
+    'prices' => [
+        // The minimum price we'll accept for online subscriptions, in pence
+        'minimum' => 1500,
+
+        // The recommended price, in pence
+        'recommended' => 2000,
+    ]
+];

--- a/resources/views/account/create.blade.php
+++ b/resources/views/account/create.blade.php
@@ -144,7 +144,7 @@ Join Hackspace Manchester
             <div class="col-sm-9 col-lg-7">
                 <div class="input-group">
                     <div class="input-group-addon">&pound;</div>
-                    {!! Form::input('number', 'monthly_subscription', 20, ['class'=>'form-control', 'placeholder'=>'20', 'min'=>'12', 'step'=>'1']) !!}
+                    {!! Form::input('number', 'monthly_subscription', $recommendedAmount / 100, ['class' => 'form-control', 'placeholder' => $recommendedAmount / 100, 'min' => $minAmount / 100, 'step' => '1']) !!}
                 </div>
                 {!! Notification::getErrorDetail('monthly_subscription') !!}
                 <span class="help-block"><button type="button" class="btn btn-link" data-toggle="modal" data-target="#howMuchShouldIPayModal">How much should I pay?</button></span>
@@ -164,8 +164,8 @@ Join Hackspace Manchester
         </ul>
         @else
         <ul>
-            <li>&pound;20 a month, like a cheap gym membership, is the recommended amount for new starters.</li>
-            <li>You can pay less, perhaps if you're on lower income, but we do ask for a minimum of &pound;15. Click the link above for more advice.</li>
+            <li>{{ MembershipPayments::formatPrice($recommendedAmount) }} a month, like a cheap gym membership, is the recommended amount for new starters.</li>
+            <li>You can pay less, perhaps if you're on lower income, but we do ask for a minimum of {{ MembershipPayments::formatPrice($minAmount) }}. Click the link above for more advice.</li>
             <li>You can pay more (&pound;25-&pound;50) if you'd like to support the space.</li>
         </ul>
         @endif
@@ -269,12 +269,12 @@ Join Hackspace Manchester
             <div class="modal-body">
                 <p>If you're not sure how much to pay, here are some general guidelines to help you find a suitable subscription amount for your circumstances:</p>
 
-                Minimum &pound;15 a month:
+                Minimum {{ MembershipPayments::formatPrice($minAmount) }} a month:
                 <ul>
                     <li>You are on a low income and unable to afford a higher amount.</li>
                 </ul>
 
-                &pound;20 a month:
+                {{ MembershipPayments::formatPrice($recommendedAmount) }} a month:
                 <ul>
                     <li>You are planning to visit the makerspace regularly and are a professional / in full-time employment</li>
                 </ul>
@@ -290,7 +290,7 @@ Join Hackspace Manchester
                 </p>
 
                 <p>
-                    If you would like to pay less than &pound;15 a month please select an amount over &pound;15 and complete
+                    If you would like to pay less than {{ MembershipPayments::formatPrice($minAmount) }} a month please select an amount over {{ MembershipPayments::formatPrice($minAmount) }} and complete
                     this form, on the next page you will be asked to setup a subscription payment.
                     Before you do this please send the board an email letting them know how much you would like to
                     pay, they will then override the amount so you can continue to setup a subscription.

--- a/resources/views/account/partials/member-status-bar.blade.php
+++ b/resources/views/account/partials/member-status-bar.blade.php
@@ -52,7 +52,7 @@
                             <div class="col-sm-6">
                                 <div class="input-group">
                                     <div class="input-group-addon">&pound;</div>
-                                    {!! Form::text('monthly_subscription', round($user->monthly_subscription), ['class'=>'form-control']) !!}
+                                    {!! Form::input('number', 'monthly_subscription', round($user->monthly_subscription), ['class' => 'form-control', 'placeholder' => MembershipPayments::getRecommendedPrice() / 100, 'min' => MembershipPayments::getMinimumPrice() / 100, 'step' => '1']) !!}
                                 </div>
                             </div>
                             <div class="col-sm-6">

--- a/resources/views/account/partials/payment-problem-panel.blade.php
+++ b/resources/views/account/partials/payment-problem-panel.blade.php
@@ -44,7 +44,7 @@
             {!! Form::open(array('method'=>'POST', 'class'=>'form-inline hidden js-alter-subscription-amount-form', 'style'=>'display:inline-block', 'route' => ['account.update-sub-payment', $user->id])) !!}
             <div class="input-group">
                 <div class="input-group-addon">&pound;</div>
-                {!! Form::text('monthly_subscription', round($user->monthly_subscription), ['class'=>'form-control']) !!}
+                {!! Form::input('number', 'monthly_subscription', round($user->monthly_subscription), ['class' => 'form-control', 'placeholder' => MembershipPayments::getRecommendedPrice() / 100, 'min' => MembershipPayments::getMinimumPrice() / 100, 'step' => '1']) !!}
             </div>
             {!! Form::submit('Update', array('class'=>'btn btn-default')) !!}
             {!! Form::close() !!}

--- a/resources/views/account/partials/setup-payment.blade.php
+++ b/resources/views/account/partials/setup-payment.blade.php
@@ -6,7 +6,7 @@
 {!! Form::open(array('method'=>'POST', 'class'=>'form-inline hidden js-alter-subscription-amount-form', 'style'=>'display:inline-block', 'route' => ['account.update-sub-payment', $user->id])) !!}
 <div class="input-group">
     <div class="input-group-addon">&pound;</div>
-    {!! Form::text('monthly_subscription', round($user->monthly_subscription), ['class'=>'form-control']) !!}
+    {!! Form::input('number', 'monthly_subscription', round($user->monthly_subscription), ['class' => 'form-control', 'placeholder' => MembershipPayments::getRecommendedPrice() / 100, 'min' => MembershipPayments::getMinimumPrice() / 100, 'step' => '1']) !!}
 </div>
 {!! Form::submit('Update', array('class'=>'btn btn-default')) !!}
 {!! Form::close() !!}

--- a/resources/views/account/partials/switch-to-gocardless-panel.blade.php
+++ b/resources/views/account/partials/switch-to-gocardless-panel.blade.php
@@ -30,7 +30,7 @@
                     {!! Form::open(array('method'=>'POST', 'class'=>'form-inline hidden js-alter-subscription-amount-form', 'style'=>'display:inline-block', 'route' => ['account.update-sub-payment', $user->id])) !!}
                     <div class="input-group">
                         <div class="input-group-addon">&pound;</div>
-                        {!! Form::text('monthly_subscription', round($user->monthly_subscription), ['class'=>'form-control']) !!}
+                        {!! Form::input('number', 'monthly_subscription', round($user->monthly_subscription), ['class' => 'form-control', 'placeholder' => MembershipPayments::getRecommendedPrice() / 100, 'min' => MembershipPayments::getMinimumPrice() / 100, 'step' => '1']) !!}
                     </div>
                     {!! Form::submit('Update', array('class'=>'btn btn-default')) !!}
                     {!! Form::close() !!}


### PR DESCRIPTION
Seeing #75, I thought it'd be easier & safer for future price changes if we had one single place defining our minimum and recommended prices.

This PR lifts those prices into a config file, which is referenced via `MembershipPayments::getMinimumPrice` or `MembershipPayments::getRecommendedPrice`.

In the future we might consider moving the configuration of prices directly into the database and exposing an admin frontend to manage them without having to make any code changes. This PR is a small step toward that.