### PR TITLE
Prepare for redeployment

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -33,10 +33,13 @@ return [
 
 		'local' => [
 			'driver' => 'local',
-			'root'   => 'img',
+			'root'   => 'img', // TODO: Move this under the 'storage' folder
 		],
 
-		
+		// TODO: Set up custom disks for
+		// - equipment-images
+		// - expenses
+		// - user-photo		
 	],
 
 ];

--- a/readme.md
+++ b/readme.md
@@ -1,55 +1,78 @@
-BBMS fork - (Hackspace Manchester Member System)
-====================
+# Hackspace Manchester Member System
+
+To manage many aspects of member's access & use of the space and its equipment, we maintain our own Hackspace Manchester Membership System. This began as a fork of [ArthurGuy/BBMembershipSystem](https://github.com/ArthurGuy/BBMembershipSystem), but has since diverged to suit the unique needs of our space & equipment.
+
+## Overview
 
 ### Features
-* Member signup form which collects full name and address, emergency contact and profile photo.
-* Direct Debit setup and payment collection through GoCardless
-* Regular monthly direct debit payment runs for each user
-* The ability for the user to edit all their details allowing for self management
-* Various user statuses to cater for active members, members who have left or been banned as well as tracking founders and honorary members
-* Handling of the induction/equipment training procedures and collection of payments.
-* Tracking of who trains who
-* Member grid to see who is a member
-* The ability for members to cancel their subscription and leave
-* Logs who has a physical key
-* Manage member storage box assignments
-* RFID door entry control and tracking
-* Member credit system for paying for various services
-* Member credit topup using direct debit payments and credit/debit card payments
-* Member role system for managing delegated duties
-* RFID access control for equipment and usage logging
-* Auto billing for equipment usage
-* Equipment/asset management
 
------
+- Member signup form which collects full name and address, emergency contact and profile photo.
+- Direct Debit setup and payment collection through GoCardless
+- Regular monthly direct debit payment runs for each user
+- The ability for the user to edit all their details allowing for self management
+- Various user statuses to cater for active members, members who have left or been banned as well as tracking founders and honorary members
+- Handling of the induction/equipment training procedures and collection of payments.
+- Tracking of who trains who
+- Member grid to see who is a member
+- The ability for members to cancel their subscription and leave
+- Logs who has a physical key
+- Manage member storage box assignments
+- RFID door entry control and tracking
+- Member credit system for paying for various services
+- Member credit topup using direct debit payments and credit/debit card payments
+- Member role system for managing delegated duties
+- RFID access control for equipment and usage logging
+- Auto billing for equipment usage
+- Equipment/asset management
 
+### Account tiers
 
-## System Functionality
+There are two primary tiers of accounts:
 
-### Online Only / SSO
-There are two forms where you can sign up
-* One is for normal membership
-* The other is online only - this is where online services use this system as a SSO provider
+- Online-only accounts: Limited access to the membership system & space, but enables participation in our community
+- Members: Those with a regular subscription for access to the space & its equipment.
 
-The flow for signing up is slightly different:
-#### Normal
-Sign up -> setup payment -> get welcome email
+The sign-up flows for each is slightly different:
 
-#### Online Only
+#### Online-only
+
 Sign up -> get online only welcome email -> confirm email
 
 Online only is stored in the DB as such. Dummy data is inserted so as not to break db constraints, but this is caught when updating your details. This means users can go from online only to a full member. They can't go back to online only at the moment - their membership will just go to being expired, but will still work for SSO.
 
+#### As a member
+
+Sign up -> setup payment -> get welcome email
 
 ### Member Statuses
+
 There are a variety of member statuses which are used for various scenarios.
-* Setting Up - just signed up, no subscription setup, no access to space
-* Active
-* Suspended - missed payment - DD is still active but the member doesn't have access to the workshop
-* Leaving - The user has said they are leaving or they were in a payment warning state, member retains full access
-* Left - Leaving users move here once their last payment expires.
+
+- Setting Up - just signed up, no subscription setup, no access to space
+- Active
+- Suspended - missed payment - DD is still active but the member doesn't have access to the workshop
+- Leaving - The user has said they are leaving or they were in a payment warning state, member retains full access
+- Left - Leaving users move here once their last payment expires.
+
+## Third-party services
+
+Running the membership system relies on a number of third-party services:
+
+- (Email provider?)
+- Discourse: Providing single-sign-on onto a Discourse application
+- GoCardless: For managing subscription payments via direct debit
+- Rollbar: For error monitoring & tracking
+- Stripe: One-off payments (only available via the "Payment problem panel")
+- Telegram: For notifying public & operational group chats about system events (new members, system notifications)
+- ~~Amazon Web Services~~ (unused)
+- ~~Paypal~~ (unused)
+- ~~Pusher~~ (unused)
+- ~~Slack~~ (unused)
+
+These can be configured via environmental variables, or by setting up a `.env` file in the root of the project. See [`.env.example`](./.env.example) for reference.
 
 ## Development
+
 The system is built on the PHP Laravel 5 framework so familiarity with that would help.
 
 A .env file needs to be setup, please take a look at the example one for the options that are needed.
@@ -57,14 +80,19 @@ This file can be renamed by removing the .example from the end.
 
 Composer needs to be available and the install command run to load the required assets.
 
-The storage directory needs to be writable. 
+The storage directory needs to be writable.
 
-Some of the config options wont be needed.<br />
-AWS is used for file storage although a local option can be specified.<br />
-The system is built for a MySQL DB but a similar system will work<br />
-GoCardless for Direct Debit payments<br />
-MailGun for sending email - completely optional<br />
-The encryption key is essential and cannot be changed or lost once set<br />
+Some of the config options wont be needed.
+
+AWS is used for file storage although a local option can be specified.
+
+The system is built for a MySQL DB but a similar system will work
+
+GoCardless for Direct Debit payments
+
+MailGun for sending email - completely optional
+
+The encryption key is essential and cannot be changed or lost once set
 
 ### Getting started
 
@@ -72,35 +100,35 @@ We have a Docker runtime adapted from Laravel Sail ([GitHub](https://github.com/
 
 Prerequisites:
 
-* [Docker](https://www.docker.com/)
-* [Docker Compose](https://docs.docker.com/compose/install/) (comes pre-installed with Docker Desktop)
+- [Docker](https://www.docker.com/)
+- [Docker Compose](https://docs.docker.com/compose/install/) (comes pre-installed with Docker Desktop)
 
 1. Set up a .env file by copying `.env.example` to `.env`.
 
 2. Install dependencies with:
 
-    ```sh
-    docker-compose run laravel composer install
-    docker-compose run laravel yarn install
-    ```
+   ```sh
+   docker-compose run laravel composer install
+   docker-compose run laravel yarn install
+   ```
 
 3. Build frontend assets with:
 
-    ```sh
-    docker-compose run laravel yarn run build
-    ```
+   ```sh
+   docker-compose run laravel yarn run build
+   ```
 
 4. Start the local runtime with:
 
-    ```sh
-    docker-compose up -d
-    ```
+   ```sh
+   docker-compose up -d
+   ```
 
 5. Provision the development database
 
-    ```sh
-    docker-compose run laravel php artisan migrate
-    ```
+   ```sh
+   docker-compose run laravel php artisan migrate
+   ```
 
 6. Visit [https://localhost:8080](https://localhost:8080)
 
@@ -134,33 +162,62 @@ Or the Laravel log file at [storage/logs/laravel-DATE.log](./storage/logs):
 tail -n 20 storage/logs/laravel-$(date -I).log
 ```
 
-### Server
-The system runs in docker
+## Deployment & hosting environments
 
-- SSH into the server
-  - ssh user@bikeshed.hacman.org.uk
-  - cd `/var/members`
-  - the code for hotfixes is at `/var/members/www/members`
-- Get into docker
-  - `docker ps` - will reveal all docker containers
-    - Note the name for the member system `members-webserver`
-  - Get into docker container `docker exec -it members-webserver bash`
-- Git pull
-  - No CI/CD set up just SSH in and pull using a personal access token
-  - `git pull origin master`
+We currently host the membership system ourselves on our Bikeshed server, using Docker to encapsulate the relevant runtime.
+
+The live Docker runtime is entirely separate to the local development runtime.
+
+Production environment:
+
+|                      |                                            |
+| -------------------- | ------------------------------------------ |
+| URL                  | <https://members.hacman.org.uk>            |
+| Server               | `bikeshed.hacman.org.uk`                   |
+| Runtime              | `/var/members/` (Docker Compose)           |
+| Source code          | `/var/members/www/members`                 |
+| Server configuration | `/var/members/config/vhosts`               |
+| Crontab              | `/etc/cron.daily/membership-daily-updates` |
+
+### Deployment process
+
+We manually deploy code changes only at the moment, avoiding any post-deployment tasks until we gain confidence in the current hosting envronment's set up & resilience.
+
+```sh
+# On Bikeshed
+
+cd /var/members/www/members
+git pull origin master
+```
+
+If we need access to the PHP runtime, we can open a shell with:
+
+```sh
+# On Bikeshed
+
+cd /var/members/
+sudo docker-compose exec webserver bash
+```
 
 ### Database
-Database is MySQL and accessible via PHPMyAdmin.
-Table is `members`
 
-### CSS
+Database access information is kept private at the moment.
+
+Ideally, database changes should be made via [Laravel Migrations](https://laravel.com/docs/5.1/migrations).
+
+If you believe any changes need making directly to the database, please contact the membership comittee.
+
+### Frontend assets
+
 The site uses Bootstrap and SCSS files which can be transpiled to CSS.
 However due to issues with transpiling that we haven't fixed, there's CSS hotfixes here and there.
 This isn't dangerous or a risk, but would be nicer if it could be integrated with the SCSS.
 
 ### Routes
+
 `app/Http/routes.php` is the starting point. Note the middlewares which do things like make
 some things member only.
 
 ### Running jobs
+
 Get into the docker container (above) and you can then run `php artisan bb:check-memberships` to run the `check-memberships` job, or any of the other jobs.

--- a/readme.md
+++ b/readme.md
@@ -71,6 +71,14 @@ Running the membership system relies on a number of third-party services:
 
 These can be configured via environmental variables, or by setting up a `.env` file in the root of the project. See [`.env.example`](./.env.example) for reference.
 
+### Storage
+
+We don't use any third-party Cloud providers for storage of files.
+
+All user-uploaded content is currently stored in the 'public/img/local' , which is symlinked to via `/public/local`.
+
+⚠️ By convention, stateful content is expected to be stored in `storage` in the Laravel ecosystem. By breaking that convention, using standard deployment tooling or guides could cause us to lose user-uploaded content.
+
 ## Development
 
 The system is built on the PHP Laravel 5 framework so familiarity with that would help.


### PR DESCRIPTION
This PR will contain any prep work toward redeploying the app on our server, with the goals of:

- Consistent permissions
- Clear deployment & management process
- Enabling post-deployment steps
  - Composer install
  - Build frontend
  - Run migrations
- Zero downtime deployments

## TODO list

(I've written a lot here.. Might need to move this into #77 and use that issue to coordinate the multiple steps of work)

### App code

- [x] Update README with up-to-date overview of hosting & deployment process
- [x] Review third-party services
- [x] Review any usage of the Storage APIs / where we store user-generated content
- [ ] Reconsolidate storage within the `storage` folder (sync up with Laravel convention, and simplify zero-downtime deployment process)
- _Any removals of dependencies / code required, from the previous steps?_
- [ ] Update README again, describing the new deployment process

### Server config

- [ ] Create new folder structure for zero-downtime deployments
  - [ ] External `storage` folder, to track state separately to app code deployments
  - [ ] Folder per deployment
- [ ] Document how to pull down & prepare a new deployment
- [ ] Document how to make a deployment live, and how to revert to an previous deployment

### Automation

We might be able to begin automating this process into the new deployments folder structure, once any prerequisite steps above are complete.

By delaying the actual swap over of the live domain and setting up a separate domain, we can host mirror-image live membership systems served from the old & new folder structures. That'll allow us to prove the new deployment process without risking downtime on the primary domain.

- [ ] Set up a separate sub domain to test the new deployment process
- [ ] Extend our `docker-compose.yml` to host a separate web server from the new folder structure
- [ ] Set up SSH access and permissions for a `deployments` user
- [ ] Set up GitHub actions
  - [ ] To be able to SSH to the server
  - [ ] Automate the "prepare new deployment" process
  - [ ] Automate the "make a deployment live" process
  - [ ] (If possible) automate the "revert deployment" process (manually triggered)
- [ ] Look into the Github Deployments API (I can't recall if that has any functionality, or if it just serves as a deployment log)