### PR TITLE
Fix equipment create page breakage

### DIFF
--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -176,7 +176,8 @@ class EquipmentController extends Controller
             ->with('memberList', $memberList)
             ->with('roleList', $roleList->toArray())
             ->with('ppeList', $this->ppeList)
-            ->with('trusted', true);
+            ->with('trusted', true)
+            ->with('isTrainerOrAdmin', \Auth::user()->isAdmin());
     }
 
 


### PR DESCRIPTION
#73 updated the form used for creating/editing equipment pages adding a new view variable, but forgot to set this variable in `EquipmentController::create`