### PR TITLE
Make sure all user uploads are stored in the "storage" folder

### DIFF
--- a/app/Entities/Equipment.php
+++ b/app/Entities/Equipment.php
@@ -125,7 +125,7 @@ class Equipment extends Model
      */
     public function getPhotoBasePath()
     {
-        return \App::environment() . '/equipment-images/';
+        return 'equipment-images/';
     }
 
     /**
@@ -157,7 +157,7 @@ class Equipment extends Model
      */
     public function getPhotoUrl($num = 1)
     {
-        return 'https://members.hacman.org.uk' . getenv('S3_BUCKET') . '/' . $this->getPhotoPath($num);
+        return asset('storage/' . $this->getPhotoPath($num));
     }
 
     public function getNumPhotos()

--- a/app/Http/Controllers/ExpensesController.php
+++ b/app/Http/Controllers/ExpensesController.php
@@ -5,6 +5,7 @@ use BB\Exceptions\ImageFailedException;
 use Carbon\Carbon;
 use Illuminate\Support\Facades\Response;
 use Illuminate\Support\Facades\Storage;
+use Input;
 
 class ExpensesController extends Controller {
 
@@ -79,16 +80,17 @@ class ExpensesController extends Controller {
 
         $this->expenseValidator->validate($data);
 
-
-        if (\Input::file('file')) {
+        $file = Input::file('file');
+        if ($file) {
             try {
-                $filePath = \Input::file('file')->getRealPath();
-                $ext = \Input::file('file')->guessClientExtension();
-                $mimeType = \Input::file('file')->getMimeType();
+                $filePath = $file->getRealPath();
+                $ext = $file->guessClientExtension();
 
-                $newFilename = \App::environment().'/expenses/' . str_random() . '.' . $ext;
+                $newFilename = sprintf('expenses/%s.%s', str_random(), $ext);
 
-                Storage::put($newFilename, file_get_contents($filePath), 'public');
+                // Should expenses be accessible publically? Or should we have them in a private directory accessonly
+                // only through an role-restricted endpoint (admin only?)?
+                Storage::disk('public')->put($newFilename, file_get_contents($filePath), 'public');
 
                 $data['file'] = $newFilename;
 

--- a/app/Presenters/ExpensePresenter.php
+++ b/app/Presenters/ExpensePresenter.php
@@ -37,7 +37,12 @@ class ExpensePresenter extends Presenter
 
     public function file()
     {
-        return 'https://members.hacman.org.uk' . env('S3_BUCKET', '') . '/' . $this->entity->file;
+        $filePath = $this->entity->file;
+
+        // Strip 'local' from the beginning, if this was saved before we moved the storage folder
+        $filePath = preg_replace('/^local\//', '', $filePath);
+
+        return asset('storage/' . $filePath);
     }
 
 } 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -32,14 +32,16 @@ return [
 	'disks' => [
 
 		'local' => [
-			'driver' => 'local',
-			'root'   => 'img', // TODO: Move this under the 'storage' folder
+			'driver' => 'local',	
+			'root'   => storage_path('app'),
 		],
 
-		// TODO: Set up custom disks for
-		// - equipment-images
-		// - expenses
-		// - user-photo		
+		'public' => [
+			'driver' => 'local',
+			'root' => storage_path('app/public'),
+			'visibility' => 'public',
+		],
+
 	],
 
 ];

--- a/public/storage
+++ b/public/storage
@@ -1,0 +1,1 @@
+../storage/app/public

--- a/readme.md
+++ b/readme.md
@@ -75,9 +75,7 @@ These can be configured via environmental variables, or by setting up a `.env` f
 
 We don't use any third-party Cloud providers for storage of files.
 
-All user-uploaded content is currently stored in the 'public/img/local' , which is symlinked to via `/public/local`.
-
-⚠️ By convention, stateful content is expected to be stored in `storage` in the Laravel ecosystem. By breaking that convention, using standard deployment tooling or guides could cause us to lose user-uploaded content.
+All user-uploaded content is stored via the public storage disk at `storage/app/public`. There is a symlink pointing to this directory at `/public/storage`. This replicates the [public storage disk](https://laravel.com/docs/5.2/filesystem#the-public-disk) introduced in Laravel 5.2 (the next version above us).
 
 ## Development
 

--- a/resources/views/account/show.blade.php
+++ b/resources/views/account/show.blade.php
@@ -164,7 +164,14 @@
             </div>
         </div>
 
-
+        {{-- Expenses functionality was removed... Uncomment this for testing. --}}
+        {{--
+        <div class="row">
+            <div class="col-xs-12 col-lg-12 pull-left">
+                <div id="memberExpenses" data-user-id="{{ $user->id }}"></div>
+            </div>
+        </div>
+        --}}
 
         @if (($user->status != 'left') && ($user->status != 'leaving'))
         <div class="row">

--- a/storage/app/public/.gitignore
+++ b/storage/app/public/.gitignore
@@ -1,3 +1,2 @@
 *
-!public/
 !.gitignore


### PR DESCRIPTION
On the path to redeploying the server, we need to consolidate all user uploads into Laravel's "storage" folder. By convention, this folder contains all stateful files and is the only folder that will be preserved across redeployments.

This PR:

- Adds a new "public" storage disk, replicating Laravel 5.2's [public storage disk](https://laravel.com/docs/5.2/filesystem#the-public-disk).
- Symlinks `public/storage` to the public storage disk – so files are indeed publicly accessible
- For user photos, equipment images, and expenses:
  - Stores newly uploaded files in the public disk
  - Update / fixes the methods generating the public-facing URLs for these images

As part of this changes, some server-side changes have also been applied:

- Create the new public storage folder on the server, `storage/app/public`
- Move existing files from `public/img/local` to `storage/app/public`
- Create a symlink from `public/img/local` to `storage/app/public`
  - This ensures currently deployed code still works when saving or serving files

Closes #84 