### PR TITLE
Fix group email address links & 404 on missing groups

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -27,7 +27,7 @@ class GroupsController extends Controller
      */
     public function show($roleName)
     {
-        $role = Role::with('Users')->where('name', $roleName)->first();
+        $role = Role::with('Users')->where('name', $roleName)->firstOrFail();
         return View::make('groups.show')->with('role', $role);
     }
 

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -25,7 +25,9 @@
                     </p>
                     @endif
                     @if ($role->email_public)
-                    Email: <a href="{{ $role->email_public }}">{{ $role->email_public }}</a>
+                    <p>
+                        Email: <a href="mailto:{{ $role->email_public }}">{{ $role->email_public }}</a>
+                    </p>
                     @endif
                 </div>
             </div>


### PR DESCRIPTION
I saw in the error logs that we were getting HTTP requests to `/groups/somebody@example.com`, which was indicative of 2 problems:

1. We're outputting email addresses somewhere without the `mailto` protocol
2. GroupController is trying to render show.php for missing groups

This PR fixes both of these issues.

Terminology note: "Roles", "groups", and "teams" all represent the same concept within our system. In the database and code it's "roles". In controller & templates its "groups", and on the site's frontend it's "teams"

## Testing

Setup:

1. Visit `/roles`
2. Set "public email" for one of the roles

Email link:

1. Visit "Teams" in the navigation
2. Click onto the team we set the "public email" against
3. See the link to the e-mail address ✅ 
4. Inspect the link, and see its prefixed with `mailto:` ✅ 
5. Click the link, and see it open in your mail client ✅ 

HTTP 404 for missing groups

1. Visit "teams" in the navigation
2. Click onto one of the teams
3. Edit the URL, and change the last segment of the URL to some random keyboard bash
4. See a 404 page ✅ 