### PR TITLE
Add query2 (active keyfobs) script

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,9 @@ SSO_KEY=
 TELEGRAM_BOT_KEY=
 TELEGRAM_BOT_CHAT=
 
+# For integration with Pi-based space access control
+QUERY2_ACCESS_KEY=
+
 # For development runtime
 WWWGROUP=1000
 WWWUSER=1000

--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,6 @@ tests/codeception/_output/*
 npm-debug.log
 storage/tmp
 database.sqlite
-/public/query2.php
 yarn-error.log
 /public/css/*.css
 /public/fonts

--- a/public/query2.php
+++ b/public/query2.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * This script will output a CSV containing the keyfob IDs and names associated with all active memberships
+ * 
+ * Our Raspberry Pi's within the space currently poll this script every few minutes. We wish to move this logic within
+ * Laravel later, but we're saving that work until we can develop a more sensible API and can update the space's access
+ * system (either the existing Pi's, or something else that's easier to manage)
+ */
+
+// Enable access to Composer dependencies (we'll indirectly have phpdotenv through our Laravel)
+require __DIR__ . '/../vendor/autoload.php';
+
+$dotenv = Dotenv::load(__DIR__ . '/../');
+Dotenv::required([
+    'QUERY2_ACCESS_KEY',
+    'DB_HOST',
+    'DB_PORT',
+    'DB_DATABASE',
+    'DB_USERNAME',
+    'DB_PASSWORD'
+]);
+
+if ($_GET['key'] !== $_ENV['QUERY2_ACCESS_KEY']) die();
+
+//Our MySQL connection details.
+$host = $_ENV['DB_HOST'];
+$port = $_ENV['DB_PORT'];
+$user = $_ENV['DB_USERNAME'];
+$password = $_ENV['DB_PASSWORD'];
+$database = $_ENV['DB_DATABASE'];
+
+//Connect to MySQL using PDO.
+$pdo = new PDO("mysql:host=$host;port=$port;dbname=$database", $user, $password);
+
+//Create our SQL query.
+$sql = <<<SQL
+SELECT key_fobs.key_id,
+    users.announce_name
+FROM key_fobs
+    LEFT JOIN users ON users.id = key_fobs.user_id
+WHERE (
+        users.status = 'active'
+        OR users.status = 'leaving'
+    )
+    AND key_fobs.Active = '1'
+SQL;
+
+//Prepare our SQL query.
+$statement = $pdo->prepare($sql);
+
+//Executre our SQL query.
+$statement->execute();
+
+//Fetch all of the rows from our MySQL table.
+$rows = $statement->fetchAll(PDO::FETCH_ASSOC);
+
+//Get the column names.
+$columnNames = array();
+if (!empty($rows)) {
+    //We only need to loop through the first row of our result
+    //in order to collate the column names.
+    $firstRow = $rows[0];
+    foreach ($firstRow as $colName => $val) {
+        $columnNames[] = $colName;
+    }
+}
+
+//Setup the filename that our CSV will have when it is downloaded.
+$fileName = 'mysql-export.csv';
+
+//Set the Content-Type and Content-Disposition headers to force the download.
+header('Content-Type: application/excel');
+header('Content-Disposition: attachment; filename="' . $fileName . '"');
+
+//Open up a file pointer
+$fp = fopen('php://output', 'w');
+
+//Start off by writing the column names to the file.
+fputcsv($fp, $columnNames);
+
+//Then, loop through the rows and write them to the CSV file.
+foreach ($rows as $row) {
+    fputcsv($fp, $row);
+}
+
+//Close the file pointer.
+fclose($fp);


### PR DESCRIPTION
This PR brings `public/query2` into the repository, with some modifications to ensure we load secrets from `.env` rather than have them hardcoded in the repository.

**Example output**

From testing locally:

```
key_id,announce_name
123124q,rjackson
ff012301230,rjackson
```

(key IDs are from keyboard bashing, not real fob IDs)

**Pre-deployment**

- [x] Set `QUERY2_ACCESS_KEY` in the live deployment's `.env`

**Rollback**

I have a copy of the original `query2.php` locally, and on the server under `/home/rob/members-backup-2022-10-31`

Closes #74