### PR TITLE
Fix inputs / handling of account balance changes

### DIFF
--- a/app/Http/Controllers/CashPaymentController.php
+++ b/app/Http/Controllers/CashPaymentController.php
@@ -35,7 +35,7 @@ class CashPaymentController extends Controller
     {
         User::findWithPermission($userId);
 
-        $amount     = \Request::get('amount') /100;
+        $amount     = \Request::get('amount');
         $reason     = \Request::get('reason');
         $sourceId   = \Request::get('source_id');
         $returnPath = \Request::get('return_path');

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -109,7 +109,7 @@ Route::post('account/{account}/payment/cash2', ['as'=>'account.payment.cash2.cre
 
 
 //Cash
-Route::group(array('middleware' => 'role:member'), function() {
+Route::group(array('middleware' => 'role:admin'), function() {
     Route::post('account/{account}/payment/cash/create', ['as'=>'account.payment.cash.create', 'uses' => 'CashPaymentController@store']);
     Route::delete('account/{account}/payment/cash', ['as'=>'account.payment.cash.destroy', 'uses' => 'CashPaymentController@destroy']);
 });

--- a/resources/views/account/partials/member-admin-action-bar.blade.php
+++ b/resources/views/account/partials/member-admin-action-bar.blade.php
@@ -111,23 +111,29 @@
                         <h4>Balance - Top up</h4>
                         <p>Use this if the member has given you some cash to top up their balance.</p>
 
-                        {!! Form::open(['method'=>'POST', 'route' => ['account.payment.cash.create', $user->id], 'class'=>'form-horizontal']) !!}
+                        {!! Form::open(['method'=>'POST', 'route' => ['account.payment.cash.create', $user->id], 'class'=>'form-inline']) !!}
 
-                        <div class="form-group">
-                            <div class="col-sm-5">
+                            <div class="form-group {{ $errors->credit->has('amount') ? 'has-error' : '' }}">
+                                <label class="sr-only" for="amount">Amount</label>
                                 <div class="input-group">
                                     <div class="input-group-addon">&pound;</div>
                                     {!! Form::input('number', 'amount', '', ['class'=>'form-control', 'step'=>'0.01', 'required'=>'required']) !!}
                                 </div>
                             </div>
-                            <div class="col-sm-3">
-                                {!! Form::submit('Add Credit', array('class'=>'btn btn-primary')) !!}
-                            </div>
-                        </div>
 
-                        {!! Form::hidden('reason', 'balance') !!}
-                        {!! Form::hidden('source_id', 'user:' . \Auth::id()) !!}
-                        {!! Form::hidden('return_path', 'account/'.$user->id) !!}
+                            {!! Form::submit('Add Credit', array('class'=>'btn btn-primary')) !!}
+
+                            <div class="help-block">
+                                <ul>
+                                    @foreach ($errors->credit->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
+                            </div>
+
+                            {!! Form::hidden('reason', 'balance') !!}
+                            {!! Form::hidden('source_id', 'user:' . \Auth::id()) !!}
+                            {!! Form::hidden('return_path', 'account/'.$user->id) !!}
                         {!! Form::close() !!}
                     </div>
 
@@ -136,22 +142,30 @@
                         <h4>Balance - Withdraw</h4>
                         <p>This will remove money from their balance, its used if your giving them cash.</p>
 
-                        {!! Form::open(['method'=>'DELETE', 'route' => ['account.payment.cash.destroy', $user->id], 'class'=>'form-horizontal']) !!}
+                        {!! Form::open(['method'=>'DELETE', 'route' => ['account.payment.cash.destroy', $user->id], 'class'=>'form-inline']) !!}
 
-                        <div class="form-group">
-                            <div class="col-sm-3">
+                            <div class="form-group {{ $errors->withdrawal->has('amount') ? 'has-error' : '' }}">
+                                <label class="sr-only" for="amount">Amount</label>
                                 <div class="input-group">
                                     <div class="input-group-addon">&pound;</div>
                                     {!! Form::input('number', 'amount', '', ['class'=>'form-control', 'step'=>'0.01', 'required'=>'required']) !!}
                                 </div>
                             </div>
-                            <div class="col-sm-3">
+
+                            <div class="form-group {{ $errors->withdrawal->has('ref') ? 'has-error' : '' }}">
+                                <label class="sr-only" for="ref">Reimbursemed via</label>
                                 {!! Form::select('ref', ['cash'=>'Cash', 'bank-transfer'=>'Bank Transfer'], null, ['class'=>'form-control']) !!}
                             </div>
-                            <div class="col-sm-3">
-                                {!! Form::submit('Remove Credit', array('class'=>'btn btn-primary')) !!}
+                            
+                            {!! Form::submit('Remove Credit', array('class'=>'btn btn-primary')) !!}
+
+                            <div class="help-block">
+                                <ul>
+                                    @foreach ($errors->withdrawal->all() as $error)
+                                        <li>{{ $error }}</li>
+                                    @endforeach
+                                </ul>
                             </div>
-                        </div>
 
                         {!! Form::hidden('return_path', 'account/'.$user->id) !!}
                         {!! Form::close() !!}


### PR DESCRIPTION
I noticed the following issues when managing my balance on the system:

- On my iPad, trying to enter decimal amounts ended up clearing the 'amount' box. This meant a payment for £1.90 because £9 somehow.
- When attempting to re-credit myself (admin functionality) to correct my balance, the credit amount was being accepted as pounds but parsed as pence. A £7 reimbursement to myself was actually crediting my account £0.07

Looking into these issues, I've fixed these issues – and a few others:

- Restricted balance modifications to just admins. It was possible, although not exposed on the frontend, for members to freely amend their own balance independently of any payments to/from the Space.
- Fixed account credits being erroneously transformed into a pence figure, when the consuming code expected pounds
- Added validation to balance changes (we cannot remove balance by crediting a negative amount, or add credit by withdrawing a negative amount)
- Fixed the React "payment module" casting numbers to floats whilst parsing controlled inputs – this was the cause of the awkward behaviour I saw on my iPad.
- Added some more validation on payment module amounts
- Added better error messaging for payment module usage

Screenshots:

![image](https://user-images.githubusercontent.com/602850/206537601-5455ccb2-7494-48a5-82e7-e3446b571634.png)

![image](https://user-images.githubusercontent.com/602850/206537716-62d15925-4867-4f6c-85e9-88c4f84376fe.png)

**Deploying this code will not fix all issues immediately** due to the React changes requiring Javascript to be re-built, which is not currently happening in our deployment process. We'll at least get the code fixed, and it'll go live when I finish getting a new deployment pipeline in-place.