### PR TITLE
Tool page tidy up and ability to email members based on induction status

### DIFF
--- a/app/Entities/Equipment.php
+++ b/app/Entities/Equipment.php
@@ -35,7 +35,7 @@ class Equipment extends Model
         'name', 'manufacturer', 'model_number', 'serial_number', 'colour', 'location', 'room', 'detail', 'slug',
         'device_key', 'description', 'help_text', 'managing_role_id', 'requires_induction', 'induction_category', 'working',
         'permaloan', 'permaloan_user_id', 'access_fee', 'photos', 'archive', 'obtained_at', 'removed_at', 'asset_tag_id',
-        'usage_cost', 'usage_cost_per', 'ppe', 'dangerous', 'induction_instructions', 'trainer_instructions', 'trained_instructions', 'docs'
+        'usage_cost', 'usage_cost_per', 'ppe', 'dangerous', 'induction_instructions', 'trainer_instructions', 'trained_instructions', 'docs', 'access_code'
     ];
 
     public function getDates()

--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -138,6 +138,8 @@ class EquipmentController extends Controller
         // Get info from the docs system
         $docs = $equipment->docs || "";
 
+        $now = new \DateTime("");
+
         return \View::make('equipment.show')
             ->with('equipmentId', $equipmentId)
             ->with('equipment', $equipment)
@@ -150,7 +152,8 @@ class EquipmentController extends Controller
             ->with('user', $user)
             ->with('isTrainerOrAdmin', $isTrainerOrAdmin)
             ->with('memberList', $memberList)
-            ->with('docs', $docs);
+            ->with('docs', $docs)
+            ->with('now', $now);
     }
 
     /**
@@ -252,7 +255,7 @@ class EquipmentController extends Controller
         $normalFields = [
             'name', 'manufacturer', 'model_number', 'serial_number', 'colour', 'room', 'detail', 'slug',
             'device_key', 'description', 'help_text', 'managing_role_id', 'working', 'usage_cost_per',
-            'permaloan', 'permaloan_user_id', 'obtained_at', 'removed_at', 'asset_tag_id', 'ppe', 'docs'
+            'permaloan', 'permaloan_user_id', 'obtained_at', 'removed_at', 'asset_tag_id', 'docs'
         ];
 
         $isTrainerOrAdmin = $this
@@ -262,7 +265,7 @@ class EquipmentController extends Controller
 
         $additionalFields = $isTrainerOrAdmin ? 
         ['dangerous', 'requires_induction', 'induction_category', 'access_fee', 'usage_cost',
-            'induction_instructions', 'trainer_instructions', 'trained_instructions'
+            'induction_instructions', 'trainer_instructions', 'trained_instructions', 'ppe', 'access_code'
         ]: [];
 
         $data = \Request::only(array_merge($additionalFields, $normalFields));

--- a/app/Http/Controllers/NotificationEmailController.php
+++ b/app/Http/Controllers/NotificationEmailController.php
@@ -151,10 +151,6 @@ class NotificationEmailController extends Controller
                 }
 
                 if($allowed){
-                    $getUser = function($item){
-                        return $item->user;
-                    };
-
                     if($status == "trainer"){
                         $users = $this->inductionRepository
                             ->getTrainersForEquipment($equipment->induction_category)

--- a/app/Http/Controllers/NotificationEmailController.php
+++ b/app/Http/Controllers/NotificationEmailController.php
@@ -5,7 +5,9 @@ use BB\Exceptions\NotImplementedException;
 use BB\Mailer\UserMailer;
 use BB\Repo\InductionRepository;
 use BB\Repo\UserRepository;
+use BB\Repo\EquipmentRepository;
 use BB\Validators\EmailNotificationValidator;
+
 
 class NotificationEmailController extends Controller
 {
@@ -23,6 +25,10 @@ class NotificationEmailController extends Controller
      * @var InductionRepository
      */
     private $inductionRepository;
+        /**
+     * @var EquipmentRepository
+     */
+    private $equipmentRepository;
 
     /**
      * @param UserRepository               $userRepository
@@ -32,10 +38,12 @@ class NotificationEmailController extends Controller
      */
     public function __construct(
         UserRepository $userRepository,
+        EquipmentRepository $equipmentRepository,
         EmailNotificationValidator $emailNotificationValidator,
         InductionRepository $inductionRepository
     ) {
         $this->userRepository             = $userRepository;
+        $this->equipmentRepository        = $equipmentRepository;
         $this->emailNotificationValidator = $emailNotificationValidator;
         $this->inductionRepository        = $inductionRepository;
     }
@@ -47,7 +55,52 @@ class NotificationEmailController extends Controller
         }
 
         $recipients = ['all' => 'All Members', 'laser_induction_members' => 'Laser Induction Members'];
-        return \View::make('notification_email.create')->with('recipients', $recipients);
+        return \View::make('notification_email.create')
+            ->with('recipients', $recipients);
+    }
+
+    public function tool($tool_id, $status)
+    {
+        $equipment = $this->equipmentRepository->findBySlug($tool_id);
+
+        if(!$equipment->requiresInduction()){
+            \Notification::error("This tool doesn't require an induction.");
+            return \Redirect::route('equipment.show', $equipment->slug);
+        }
+
+        $statuses = [
+            "awaiting_training" => "awaiting training",
+            "trained" => "trained",
+            "trainer" => "trainer/maintainer"
+        ];
+
+        if(!array_key_exists($status, $statuses)){
+            throw new NotImplementedException("Recipient not supported");
+        }
+
+        // Check the user is an admin or a trainer of the tool they specified
+        $trainers  = $this->inductionRepository->getTrainersForEquipment($equipment->induction_category);
+        $allowed = false;
+
+        if(\Auth::user()->isAdmin()){
+            $allowed = true;
+        }
+
+        foreach($trainers as $t){
+            if(\Auth::user()->id == $t->user->id){
+                $allowed = true;
+            }
+        }
+
+        if(!$allowed){
+            \Notification::error("You may not email members, as you aren't a trainer of this tool, or an admin");
+            return \Redirect::route('equipment.show', $equipment->slug);
+        }
+
+        return \View::make('notification_email.tool')
+            ->with("equipment", $equipment)
+            ->with("statuses", $statuses)
+            ->with("status", $status);
     }
 
     public function store()
@@ -56,11 +109,17 @@ class NotificationEmailController extends Controller
 
         $this->emailNotificationValidator->validate($input);
 
-        //This is for admins only unless they are part of a group, then they have access to specific lists
-        if ( ! \Auth::user()->isAdmin() && ! \Auth::user()->hasRole('laser')) {
+        $parts = explode('/', $input['recipient']);
+        $isToolEmail = false;
 
+        if(count($parts) == 3){
+            if($parts[0] == "tool"){
+                $isToolEmail = true;
+                $tool_slug = $parts[1];
+                $status = $parts[2];
+                $equipment = $this->equipmentRepository->findBySlug($tool_slug);
+            }
         }
-
 
         if ($input['send_to_all']) {
 
@@ -69,33 +128,84 @@ class NotificationEmailController extends Controller
                     throw new AuthenticationException("You don't have permission to send to this group");
                 }
                 $users = $this->userRepository->getActive();
-            } else {
-                if ($input['recipient'] == 'laser_induction_members') {
+            } elseif($isToolEmail){
 
-                    if ( ! \Auth::user()->hasRole('laser')) {
-                        throw new AuthenticationException("You don't have permission to send to this group");
-                    }
-
-                    $users = $this->inductionRepository->getUsersForEquipment('laser');
-                } else {
+                
+                
+                if(!in_array($status, ["trainer", "trained", "awaiting_training"])){
                     throw new NotImplementedException("Recipient not supported");
                 }
+
+                //TODO: look at how to tidy this up, as it's duplicated above
+                $trainers  = $this->inductionRepository->getTrainersForEquipment($equipment->induction_category);
+                $allowed = false;
+
+                if(\Auth::user()->isAdmin()){
+                    $allowed = true;
+                }
+
+                foreach($trainers as $t){
+                    if(\Auth::user()->id == $t->user->id){
+                        $allowed = true;
+                    }
+                }
+
+                if($allowed){
+                    $getUser = function($item){
+                        return $item->user;
+                    };
+
+                    if($status == "trainer"){
+                        $users = $this->inductionRepository
+                            ->getTrainersForEquipment($equipment->induction_category)
+                            ->map(function($item){
+                                return $item->user;
+                            });
+                    }elseif($status == "trained"){
+                        $users = $this->inductionRepository
+                            ->getTrainedUsersForEquipment($equipment->induction_category)
+                            ->map(function($item){
+                                return $item->user;
+                            });
+                    }elseif($status == "awaiting_training"){
+                        $users = $this->inductionRepository
+                            ->getUsersPendingInductionForEquipment($equipment->induction_category)
+                            ->map(function($item){
+                                return $item->user;
+                            });
+                    }
+                }
+
+                
             }
+
+
             foreach ($users as $user) {
                 $notification = new UserMailer($user);
-                $notification->sendNotificationEmail($input['subject'], nl2br($input['message']));
+                if($isToolEmail){
+                    $notification->sendEquipmentNotificationEmail($input['subject'], nl2br($input['message']), $equipment->name, $status);
+                }else{
+                    $notification->sendNotificationEmail($input['subject'], nl2br($input['message']));
+                }
             }
 
+            
         } else {
-
             //Just send to the current user
             $notification = new UserMailer(\Auth::user());
-            $notification->sendNotificationEmail($input['subject'], nl2br($input['message']));
-
+            if($isToolEmail){
+                $notification->sendEquipmentNotificationEmail($input['subject'], nl2br($input['message']), $equipment->name, $status);
+            }else{
+                $notification->sendNotificationEmail($input['subject'], nl2br($input['message']));
+            } 
+        }
+        
+        if($isToolEmail){
+            \Notification::success("Email Queued to Send to `$equipment->name` equipment users with status of `$status`");
+            return \Redirect::route('equipment.show', $equipment->slug);
         }
 
-
         \Notification::success('Email Queued to Send');
-        return \Redirect::route('notificationemail.create');
+        return \Redirect::route('home');
     }
 } 

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -244,6 +244,7 @@ Route::get('stats/history', ['uses'=>'StatsController@history', 'middleware'=>'r
 # Notification Emails
 ##########################
 
+Route::get('notification_email/equipment/{tool_id}/status/{status}', ['as' => 'notificationemail.equipment', 'uses' => 'NotificationEmailController@tool', 'middleware'=>'role:member']);
 Route::get('notification_email/create', ['as' => 'notificationemail.create', 'uses' => 'NotificationEmailController@create', 'middleware'=>'role:member']);
 Route::post('notification_email', ['as' => 'notificationemail.store', 'uses' => 'NotificationEmailController@store', 'middleware'=>'role:member']);
 

--- a/app/Mailer/UserMailer.php
+++ b/app/Mailer/UserMailer.php
@@ -113,7 +113,7 @@ class UserMailer
                 'training_status'=>$training_status
             ], 
             function ($message) use ($user, $subject) {
-            $message->addReplyTo('board@hacman.org.uk', 'Hackspace Manchester Board');
+            $message->addReplyTo('info@hacman.org.uk', 'Hackspace Manchester Info');
             $message->to($user->email, $user->email)->subject($subject);
             }
         );

--- a/app/Mailer/UserMailer.php
+++ b/app/Mailer/UserMailer.php
@@ -92,11 +92,31 @@ class UserMailer
 
     public function sendNotificationEmail($subject, $message)
     {
+        //TODO, check if sent by trainer and apply template with correct signature
         $user = $this->user;
         \Mail::queue('emails.notification', ['messageBody'=>$message, 'user'=>$user], function ($message) use ($user, $subject) {
             $message->addReplyTo('board@hacman.org.uk', 'Hackspace Manchester Board');
             $message->to($user->email, $user->email)->subject($subject);
         });
+    }
+ 
+    public function sendEquipmentNotificationEmail($subject, $message, $equipment_name, $training_status)
+    {
+        //TODO, check if sent by trainer and apply template with correct signature
+        $user = $this->user;
+        \Mail::queue(
+            'emails.equipment-notification', 
+            [
+                'messageBody'=>$message, 
+                'user'=>$user, 
+                'equipment_name'=>$equipment_name, 
+                'training_status'=>$training_status
+            ], 
+            function ($message) use ($user, $subject) {
+            $message->addReplyTo('board@hacman.org.uk', 'Hackspace Manchester Board');
+            $message->to($user->email, $user->email)->subject($subject);
+            }
+        );
     }
 
     public function sendSuspendedMessage()

--- a/app/Presenters/EquipmentPresenter.php
+++ b/app/Presenters/EquipmentPresenter.php
@@ -32,6 +32,21 @@ class EquipmentPresenter extends Presenter
         return Markdown::defaultTransform($this->entity->description);
     }
 
+    public function induction_instructions()
+    {
+        return Markdown::defaultTransform($this->entity->induction_instructions);
+    }
+
+    public function trained_instructions()
+    {
+        return Markdown::defaultTransform($this->entity->trained_instructions);
+    }
+
+    public function trainer_instructions()
+    {
+        return Markdown::defaultTransform($this->entity->trainer_instructions);
+    }
+
     public function help_text()
     {
         return Markdown::defaultTransform($this->entity->help_text);

--- a/database/migrations/2023_05_27_202336_add_access_code_to_equipment.php
+++ b/database/migrations/2023_05_27_202336_add_access_code_to_equipment.php
@@ -1,0 +1,32 @@
+<?php
+
+use BB\Entities\Settings;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class AddAccessCodeToEquipment extends Migration
+{
+     /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('equipment', function(Blueprint $table) {
+            $table->string('access_code')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('equipment', function(Blueprint $table) {
+            $table->dropColumn('access_code');
+        });
+    }
+}

--- a/resources/assets/less/application.less
+++ b/resources/assets/less/application.less
@@ -73,6 +73,7 @@
 @import "components/get-started.less";
 @import "components/infobox.less";
 @import "components/member-status-bar.less";
+@import "components/tool-info.less";
 @import "components/progress-bars.less";
 @import "components/signposts.less";
 

--- a/resources/assets/less/components/infobox.less
+++ b/resources/assets/less/components/infobox.less
@@ -29,13 +29,7 @@
     @media screen and (min-width: @screen-md) {
         &__grid {
             display: grid;
-            grid-template-columns: 1fr 1fr 1fr;
-            grid-template-areas: 
-                "header header ."
-                "main main main"
-                "main main main"
-                "main main main"
-                "footer footer footer";
+            grid-template-columns: 1fr 1fr 1fr 1fr;
             grid-gap: 1em;
             padding: 1em;
         }
@@ -47,18 +41,28 @@
         border: 1px solid black;
         border-left-width: 3px;
         padding: 1em;
-        background-color: white;
+        
+        background-color: #fff;
+        display: flex;
+        flex-direction: column;
 
         &--header{ 
-            grid-area: header;
+            grid-column-end: -1;
+            grid-column-start: 1;
         }
-        &--main{ 
-            grid-area: main;
+        &--main{  
             grid-column: auto;
             grid-row: auto;
         }
         &--footer{ 
-            grid-area: footer;
+            grid-column-end: -1;
+            grid-column-start: 1;
+        }
+
+        &--user{
+            background-color: #eee;
+            background-blend-mode: overlay;
+            background-size: cover;
         }
     }
 }

--- a/resources/assets/less/components/infobox.less
+++ b/resources/assets/less/components/infobox.less
@@ -58,11 +58,5 @@
             grid-column-end: -1;
             grid-column-start: 1;
         }
-
-        &--user{
-            background-color: #eee;
-            background-blend-mode: overlay;
-            background-size: cover;
-        }
     }
 }

--- a/resources/assets/less/components/tool-info.less
+++ b/resources/assets/less/components/tool-info.less
@@ -1,0 +1,24 @@
+.tool-info {
+    display: flex;
+    flex-direction: column;
+    border: 1px solid #000;
+
+    &__detail {
+        display: flex;
+        flex-direction: row;
+        background: linear-gradient(90deg, #fffaaa 0%, #fff 100%);
+    }
+
+    &__detail:not(:last-of-type) {
+        border-bottom: 1px solid black;
+    }
+    
+    &__key, &__value {
+        flex: 1;
+        padding: 0.5em;
+    }
+
+    &__key {
+        font-weight: bold;
+    }
+}

--- a/resources/views/account/edit.blade.php
+++ b/resources/views/account/edit.blade.php
@@ -224,7 +224,7 @@ Edit your details
 
 <h2 id="access">Key Fobs and Access Codes</h4>
 @if (!$user->online_only)
-    @if($user->induction_completed)
+    @if($user->isAdmin() || $user->induction_completed || $user->keyFobs()->count() > 0)
         <div class="panel panel-info">
             <div class="panel-heading">Getting into the space</b></div>
             <div class="panel-body">
@@ -289,62 +289,51 @@ Edit your details
         @endif
 
         <h3>Add a new entry method</h3>
-        @if ($user->induction_completed)
-            @if ($user->keyFobs()->count() < 2)
-                <div class="panel panel-success">
-                    <div class="panel-heading">Add a new entry method</div>
-                    <div class="panel-body">
-                        <div class="row">
-                            <div class="col-md-6">
-                                <h4>Add a keyfob</h4>
-                                
-                                <div class="panel panel-info">
-                                    <div class="panel-heading">How to add an entry method using the membership PC</div>
-                                    <div class="panel-body">
-                                        <p><strong>In the hackspace?</strong> Select a fob from the pot, or use a compatible 13.56Mhz fob you already have, select the text box below, then scan your fob with the reader. The ID will be typed in.</p>   
-                                    </div>
-                                </div>
-                                
-                                {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                                <div class="form-group">
-                                    <div class="col-sm-5">
-                                        {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
-                                        Characters A-F and numbers 0-9 only.
-                                    </div>
-                                    <div class="col-sm-3">
-                                        {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
-                                    </div>
-                                </div>
-                                {!! Form::close() !!}
-                            </div>
-                            <div class="col-md-6">
-                                <h4>Request access code</h4>
-                                {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
-                                <div class="form-group">
-                                    <div class="col-sm-3">
-                                        {!! Form::hidden('key_id', 'ff00000000') !!}
-                                        {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
-                                    </div>
-                                </div>
-                                {!! Form::close() !!}
-                               
-                            </div>
-                        </div>  
-                    </div>
-                </div>
-            @else
-                <p>You have added the maximum number of entry methods permitted.</p>
-            @endif
-        @else
-            <div class="panel panel-warning">
-                <div class="panel-heading">You need to do your online general induction</div>
+    
+        @if (($user->keyFobs()->count() < 2 && $user->induction_completed) || $user->isAdmin())
+            <div class="panel panel-success">
+                <div class="panel-heading">Add a new entry method</div>
                 <div class="panel-body">
-                    <p>
-                        You must <a href="/account/0/induction">complete your General Induction</a> before you can get physical access to the space.<br>
-                        This is so you understand and agree to the rules.
-                    </p>
+                    <div class="row">
+                        <div class="col-md-6">
+                            <h4>Add a keyfob</h4>
+                            
+                            <div class="panel panel-info">
+                                <div class="panel-heading">How to add an entry method using the membership PC</div>
+                                <div class="panel-body">
+                                    <p><strong>In the hackspace?</strong> Select a fob from the pot, or use a compatible 13.56Mhz fob you already have, select the text box below, then scan your fob with the reader. The ID will be typed in.</p>   
+                                </div>
+                            </div>
+                            
+                            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                            <div class="form-group">
+                                <div class="col-sm-5">
+                                    {!! Form::text('key_id', '', ['class'=>'form-control']) !!}
+                                    Characters A-F and numbers 0-9 only.
+                                </div>
+                                <div class="col-sm-3">
+                                    {!! Form::submit('Add a new fob', array('class'=>'btn btn-primary')) !!}
+                                </div>
+                            </div>
+                            {!! Form::close() !!}
+                        </div>
+                        <div class="col-md-6">
+                            <h4>Request access code</h4>
+                            {!! Form::open(array('method'=>'POST', 'route' => ['keyfob.store'], 'class'=>'form-horizontal')) !!}
+                            <div class="form-group">
+                                <div class="col-sm-3">
+                                    {!! Form::hidden('key_id', 'ff00000000') !!}
+                                    {!! Form::submit('Request access code', array('class'=>'btn btn-info')) !!}
+                                </div>
+                            </div>
+                            {!! Form::close() !!}
+                            
+                        </div>
+                    </div>  
                 </div>
             </div>
+        @else
+            <p>You have added the maximum number of entry methods permitted.</p>
         @endif
     @else
         <div class="alert alert-warning">

--- a/resources/views/emails/equipment-notification.blade.php
+++ b/resources/views/emails/equipment-notification.blade.php
@@ -9,7 +9,7 @@
 </h3>
 
 <p style="border-left: 3px solid blue; padding: 10px;">
-    This email has been sent to all members who are marked as <strong>{{ $training_status }}</strong> on the {{$equipment_name}}.
+    This notification email has been sent to all members who are marked as <strong>{{ $training_status }}</strong> on the {{$equipment_name}}.
 </p>
 
 <p>Message content:</p>
@@ -19,9 +19,9 @@
 
 
 <p>
-    This email was sent by the <a href="{{ URL::route('home') }}">Hackspace Manchester Member System</a>.<br><br>
+    This is a notification email, replies are best directed towards <a href="https://list.hacman.org.uk">the forum</a> or Telegram. This email was sent by the <a href="{{ URL::route('home') }}">Hackspace Manchester Member System</a>, without the sender having access to your email address.<br><br>
     <em>
-        Note: the sender may not have access to email addresses. If you wish to unsubscribe, either reply to the board asking to be removed from the training list, or log in and cancel your training request.
+        To unsubscribe, log in to the membership system and cancel your training request (quickest, and preferred), or reply to this email with "unsubscribe" (there may be a delay).
     </em>
 </p>
 

--- a/resources/views/emails/equipment-notification.blade.php
+++ b/resources/views/emails/equipment-notification.blade.php
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en-GB">
+<head>
+    <meta charset="utf-8">
+</head>
+<body>
+<h3>
+    Hi {{ $user->given_name }},
+</h3>
+
+<p style="border-left: 3px solid blue; padding: 10px;">
+    This email has been sent to all members who are marked as <strong>{{ $training_status }}</strong> on the {{$equipment_name}}.
+</p>
+
+<p>Message content:</p>
+<p style="background-color:#eee; background:repeating-linear-gradient(45deg, #fafafa, #fafafa 40px, #fff 40px, #fff 80px); padding: 15px; border: 1px solid #fafafa;">
+    {!! $messageBody !!}
+</p>
+
+
+<p>
+    This email was sent by the <a href="{{ URL::route('home') }}">Hackspace Manchester Member System</a>.<br><br>
+    <em>
+        Note: the sender may not have access to email addresses. If you wish to unsubscribe, either reply to the board asking to be removed from the training list, or log in and cancel your training request.
+    </em>
+</p>
+
+</body>
+</html>

--- a/resources/views/equipment/form.blade.php
+++ b/resources/views/equipment/form.blade.php
@@ -3,165 +3,170 @@
         🔒 Some information may only be edited by trainers of this tool or admins.<br/>
     </div>
 @stop
-<div class="form-group {{ Notification::hasErrorDetail('name', 'has-error has-feedback') }}">
-    {!! Form::label('name', 'Name', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('name', null, ['class'=>'form-control']) !!}
-        <p class="help-block">Aim for a short but descriptive name, i.e. Metal Bandsaw</p>
-        {!! Notification::getErrorDetail('name') !!}
+
+<h3>Name</h3>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('name', 'has-error has-feedback') }}">
+            {!! Form::label('name', 'Name', ['class'=>'']) !!}
+            {!! Form::text('name', null, ['class'=>'form-control']) !!}
+            <p class="help-block">Aim for a short but descriptive name, i.e. Metal Bandsaw</p>
+            {!! Notification::getErrorDetail('name') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('slug', 'has-error has-feedback') }}">
+            {!! Form::label('slug', 'Slug', ['class'=>'']) !!}
+            {!! Form::text('slug', null, ['class'=>'form-control']) !!}
+            <p class="help-block">This is the unique reference for the item, no special characters. i.e. metal-bandsaw or cordless-drill-1</p>
+            {!! Notification::getErrorDetail('slug') !!}
+        
+        </div>
     </div>
 </div>
 
-<div class="form-group {{ Notification::hasErrorDetail('slug', 'has-error has-feedback') }}">
-    {!! Form::label('slug', 'Slug', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('slug', null, ['class'=>'form-control']) !!}
-        <p class="help-block">This is the unique reference for the item, no special characters. i.e. metal-bandsaw or cordless-drill-1</p>
-        {!! Notification::getErrorDetail('slug') !!}
+<h3>Tool Properties</h3>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('family_name', 'has-error has-feedback') }}">
+            {!! Form::label('manufacturer', 'Manufacturer', ['class'=>'']) !!}
+            {!! Form::text('manufacturer', null, ['class'=>'form-control']) !!}
+            {!! Notification::getErrorDetail('manufacturer') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('model_number', 'has-error has-feedback') }}">
+            {!! Form::label('model_number', 'Model Number', ['class'=>'']) !!}
+            {!! Form::text('model_number', null, ['class'=>'form-control']) !!}
+            {!! Notification::getErrorDetail('model_number') !!}
+            <p class="help-block"></p>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('serial_number', 'has-error has-feedback') }}">
+            {!! Form::label('serial_number', 'Serial Number', ['class'=>'']) !!}
+            {!! Form::text('serial_number', null, ['class'=>'form-control']) !!}
+            {!! Notification::getErrorDetail('serial_number') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('colour', 'has-error has-feedback') }}">
+            {!! Form::label('colour', 'Colour', ['class'=>'']) !!}
+            {!! Form::text('colour', null, ['class'=>'form-control']) !!}
+            <p class="help-block">A rough guide such as grey or blue/green</p>
+            {!! Notification::getErrorDetail('colour') !!}
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('permaloan', 'has-error has-feedback') }}">
+            {!! Form::label('permaloan', 'Permaloan', ['class'=>'']) !!}
+            {!! Form::select('permaloan', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control']) !!}
+            <p class="help-block">Is this item on permanent loan from a member?</p>
+            {!! Notification::getErrorDetail('permaloan') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('permaloan_user_id', 'has-error has-feedback') }}">
+            {!! Form::label('permaloan_user_id', 'Permaloan Owner', ['class'=>'']) !!}
+            {!! Form::select('permaloan_user_id', [''=>'']+$memberList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
+            <p class="help-block">If its being loaned who owns it?</p>
+            {!! Notification::getErrorDetail('permaloan_user_id') !!}
+        </div>
     </div>
 </div>
 
-<div class="form-group {{ Notification::hasErrorDetail('family_name', 'has-error has-feedback') }}">
-    {!! Form::label('manufacturer', 'Manufacturer', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('manufacturer', null, ['class'=>'form-control']) !!}
-        {!! Notification::getErrorDetail('manufacturer') !!}
+
+<h3>Location and status</h3>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('room', 'has-error has-feedback') }}">
+            {!! Form::label('room', 'Room', ['class'=>'']) !!}
+            {!! Form::select('room', ['woodwork'=>'Woody Dusty', 'metalworking'=>'Metalwork', 'visual-arts'=>'Visual Arts', 'electronics'=>'Electronics','main-room'=>'Main Room'], null, ['class'=>'form-control']) !!}
+            {!! Notification::getErrorDetail('room') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('detail', 'has-error has-feedback') }}">
+            {!! Form::label('detail', 'Detail', ['class'=>'']) !!}
+            {!! Form::text('detail', null, ['class'=>'form-control']) !!}
+            <p class="help-block">Where in the room is it kept?</p>
+            {!! Notification::getErrorDetail('detail') !!}
+        </div>
+    </div>
+</div>
+<div class="row">
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('working', 'has-error has-feedback') }}">
+            {!! Form::label('working', 'Working', ['class'=>'']) !!}
+            {!! Form::select('working', [1=>'Yes', 0=>'No'], null, ['class'=>'form-control']) !!}
+            <p class="help-block">Is the equipment ready for use?</p>
+            {!! Notification::getErrorDetail('working') !!}
+        </div>
+    </div>
+    <div class="col-md-6">
+        <div class="{{ Notification::hasErrorDetail('managing_role_id', 'has-error has-feedback') }}">
+            {!! Form::label('managing_role_id', 'Managing Group', ['class'=>'']) !!}
+            {!! Form::select('managing_role_id', [''=>'']+$roleList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
+            <p class="help-block">Is a group is responsible for this piece of equipment?</p>
+            {!! Notification::getErrorDetail('managing_role_id') !!}
+        </div>
     </div>
 </div>
 
-
-<div class="form-group {{ Notification::hasErrorDetail('model_number', 'has-error has-feedback') }}">
-    {!! Form::label('model_number', 'Model Number', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('model_number', null, ['class'=>'form-control']) !!}
-        {!! Notification::getErrorDetail('model_number') !!}
+<div class="row">
+    <div class="col-md-12">
+        <div class="{{ Notification::hasErrorDetail('description', 'has-error has-feedback') }}">
+            {!! Form::label('description', 'Description', ['class'=>'']) !!}
+            {!! Form::textarea('description', null, ['class'=>'form-control']) !!}
+            <p class="help-block">Use markdown for formatting</p>
+            {!! Notification::getErrorDetail('description') !!}
+        </div>
     </div>
 </div>
 
-
-<div class="form-group {{ Notification::hasErrorDetail('serial_number', 'has-error has-feedback') }}">
-    {!! Form::label('serial_number', 'Serial Number', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('serial_number', null, ['class'=>'form-control']) !!}
-        {!! Notification::getErrorDetail('serial_number') !!}
+<div class="row">
+    <div class="col-md-12">
+        <div class="form-group {{ Notification::hasErrorDetail('docs', 'has-error has-feedback') }}">
+            {!! Form::label('docs', 'Link to documentation system', ['class'=>'col-sm-3 control-label']) !!}
+            <div class="col-sm-9 col-lg-7">
+                {!! Form::text('docs', null, ['class'=>'form-control']) !!}
+                <p class="help-block">
+                    Enter a link to the documentation system for this tool.
+                </p>
+                {!! Notification::getErrorDetail('docs') !!}
+            </div>
+        </div>
     </div>
 </div>
-
-<div class="form-group {{ Notification::hasErrorDetail('colour', 'has-error has-feedback') }}">
-    {!! Form::label('colour', 'Colour', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('colour', null, ['class'=>'form-control']) !!}
-        <p class="help-block">A rough guide such as grey or blue/green</p>
-        {!! Notification::getErrorDetail('colour') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('room', 'has-error has-feedback') }}">
-    {!! Form::label('room', 'Room', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('room', ['woodwork'=>'Woody Dusty', 'metalworking'=>'Metalwork', 'visual-arts'=>'Visual Arts', 'electronics'=>'Electronics','main-room'=>'Main Room'], null, ['class'=>'form-control']) !!}
-        {!! Notification::getErrorDetail('room') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('detail', 'has-error has-feedback') }}">
-    {!! Form::label('detail', 'Detail', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('detail', null, ['class'=>'form-control']) !!}
-        <p class="help-block">Where in the room is it kept?</p>
-        {!! Notification::getErrorDetail('detail') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('device_key', 'has-error has-feedback') }}">
-    {!! Form::label('device_key', 'Device Key', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('device_key', null, ['class'=>'form-control']) !!}
-        <p class="help-block">The id of a ACS device already setup in the database</p>
-        {!! Notification::getErrorDetail('device_key') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('description', 'has-error has-feedback') }}">
-    {!! Form::label('description', 'Description', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::textarea('description', null, ['class'=>'form-control']) !!}
-        {!! Notification::getErrorDetail('description') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('docs', 'has-error has-feedback') }}">
-    {!! Form::label('docs', 'Link to documentation system', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::text('docs', null, ['class'=>'form-control']) !!}
-        <p class="help-block">
-            Enter a link to the documentation system for this tool.
-        </p>
-        {!! Notification::getErrorDetail('docs') !!}
-    </div>
-</div>
-
 
 <div class="form-group {{ Notification::hasErrorDetail('help_text', 'has-error has-feedback') }}">
     {!! Form::label('help_text', 'Help Text', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
         {!! Form::textarea('help_text', null, ['class'=>'form-control']) !!}
-        <p class="help-block">A lot of text can go in here, useful for things like safety or maintenance information</p>
+        <p class="help-block">Helpful hints - make sure to keep most information on the documentation system.</p>
         {!! Notification::getErrorDetail('help_text') !!}
     </div>
 </div>
 
-<div class="form-group {{ Notification::hasErrorDetail('ppe', 'has-error has-feedback') }}">
-    {!! Form::label('ppe', 'PPE', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('ppe[]', [''=>'']+$ppeList, null, ['class'=>'form-control js-advanced-dropdown', 'multiple']) !!}
-        {!! Notification::getErrorDetail('ppe') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('managing_role_id', 'has-error has-feedback') }}">
-    {!! Form::label('managing_role_id', 'Managing Group', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('managing_role_id', [''=>'']+$roleList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
-        <p class="help-block">Is a group is responsible for this piece of equipment?</p>
-        {!! Notification::getErrorDetail('managing_role_id') !!}
-    </div>
-</div>
-
-
-<div class="form-group {{ Notification::hasErrorDetail('working', 'has-error has-feedback') }}">
-    {!! Form::label('working', 'Working', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('working', [1=>'Yes', 0=>'No'], null, ['class'=>'form-control']) !!}
-        <p class="help-block">Is the equipment ready for use?</p>
-        {!! Notification::getErrorDetail('working') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('permaloan', 'has-error has-feedback') }}">
-    {!! Form::label('permaloan', 'Permaloan', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('permaloan', [0=>'No', 1=>'Yes'], null, ['class'=>'form-control']) !!}
-        <p class="help-block">Is this item on <a href="{{ route('resources.policy.view', 'permaloan') }}">permanent loan</a> from a member?</p>
-        {!! Notification::getErrorDetail('permaloan') !!}
-    </div>
-</div>
-
-<div class="form-group {{ Notification::hasErrorDetail('permaloan_user_id', 'has-error has-feedback') }}">
-    {!! Form::label('permaloan_user_id', 'Permaloan Owner', ['class'=>'col-sm-3 control-label']) !!}
-    <div class="col-sm-9 col-lg-7">
-        {!! Form::select('permaloan_user_id', [''=>'']+$memberList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
-        <p class="help-block">If its being loaned who owns it?</p>
-        {!! Notification::getErrorDetail('permaloan_user_id') !!}
-    </div>
-</div>
 
 <h4>Health, Safety, Training and Inductions</h4>
 <div class="alert alert-info">
     To maintain the integrity of H&S and the training system, only admins and trainers can edit this section.<br/>
     <b>{{ $isTrainerOrAdmin ? "✔️ You can read/write the fields in this area" : "🔒 The fields in this area can not be edited at the moment"}}</b>
 </div>
-<hr/>
+
+<div class="form-group {{ Notification::hasErrorDetail('ppe', 'has-error has-feedback') }}">
+    {!! Form::label('ppe', 'PPE', ['class'=>'col-sm-3 control-label']) !!}
+    <div class="col-sm-9 col-lg-7">
+        {!! Form::select('ppe[]', [''=>'']+$ppeList, null, ['class'=>'form-control js-advanced-dropdown', 'multiple', $isTrainerOrAdmin ? "" : "disabled"]) !!}
+        {!! Notification::getErrorDetail('ppe') !!}
+    </div>
+</div>
+
 
 <div class="form-group alert-danger {{ Notification::hasErrorDetail('dangerous', 'has-error has-feedback') }}">
     {!! Form::label('dangerous', 'Is Bloody Dangerous?', ['class'=>'col-sm-3 control-label']) !!}
@@ -215,11 +220,21 @@
     </div>
 </div>
 
+<div class="form-group {{ Notification::hasErrorDetail('access_code', 'has-error has-feedback') }}">
+    {!! Form::label('access_code', 'Access Code (e.g. for padlock)', ['class'=>'col-sm-3 control-label']) !!}
+    <div class="col-sm-9 col-lg-7">
+        {!! $isTrainerOrAdmin ? Form::text('access_code', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
+        <p class="help-block">The access code, if applicable, for this tool to be used.</p>
+        {!! Notification::getErrorDetail('access_code') !!}
+    </div>
+</div>
+
 <div class="form-group {{ Notification::hasErrorDetail('induction_instructions', 'has-error has-feedback') }}">
     {!! Form::label('induction_instructions', 'Induction Instructions', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
         {!! $isTrainerOrAdmin ? Form::textarea('induction_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel'] !!}
         <p class="help-block">Instructions on what to do once an induction is requested. e.g. visit a telegram group.</p>
+        <p class="help-block">Use markdown for formatting</p>
         {!! Notification::getErrorDetail('induction_instructions') !!}
     </div>
 </div>
@@ -229,6 +244,7 @@
     <div class="col-sm-9 col-lg-7">
         {!! $isTrainerOrAdmin ? Form::textarea('trained_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Instructions for trained users - such as reminders or access codes</p>
+        <p class="help-block">Use markdown for formatting</p>
         {!! Notification::getErrorDetail('trained_instructions') !!}
     </div>
 </div>
@@ -238,17 +254,27 @@
     <div class="col-sm-9 col-lg-7">
         {!! $isTrainerOrAdmin ? Form::textarea('trainer_instructions', null, ['class'=>'form-control']) : View::getSections()['trustLevel']  !!}
         <p class="help-block">Only trainers see this - e.g. documents to risk assessments</p>
+        <p class="help-block">Use markdown for formatting</p>
         {!! Notification::getErrorDetail('trainer_instructions') !!}
     </div>
 </div>
-<hr/>
 
+<h3>Misc</h3>
 <div class="form-group {{ Notification::hasErrorDetail('asset_tag_id', 'has-error has-feedback') }}">
     {!! Form::label('asset_tag_id', 'Asset Tag ID', ['class'=>'col-sm-3 control-label']) !!}
     <div class="col-sm-9 col-lg-7">
         {!! Form::text('asset_tag_id', null, ['class'=>'form-control']) !!}
         <p class="help-block">If an asset tag is being placed onto this piece of equipment whats the ID?</p>
         {!! Notification::getErrorDetail('asset_tag_id') !!}
+    </div>
+</div>
+
+<div class="form-group {{ Notification::hasErrorDetail('device_key', 'has-error has-feedback') }}">
+    {!! Form::label('device_key', 'Device Key', ['class'=>'col-sm-3 control-label']) !!}
+    <div class="col-sm-9 col-lg-7">
+        {!! Form::text('device_key', null, ['class'=>'form-control']) !!}
+        <p class="help-block">The id of a ACS device already setup in the database</p>
+        {!! Notification::getErrorDetail('device_key') !!}
     </div>
 </div>
 

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -275,9 +275,9 @@ Tools and Equipment
                 <p>These people can train others and maintain the tool - if there's any issues with the tool speak to them.</p>
                 <div class="infobox__grid">
                     @foreach($trainers as $trainer)
-                        <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainer->user->hash) !!}')">
+                        <div class="infobox__grid-item infobox__grid-item--user">
                             <a href="{{ route('members.show', $trainer->user->id) }}">
-                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
+                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, 'hidden-sm') !!}
                             </a>
                             {{ $trainer->user->name }}
                             <div>
@@ -311,8 +311,9 @@ Tools and Equipment
                 <p>There are currently <strong>{{ count($trainedUsers) }}</strong> members who are trained to use this tool.</p>
                 <div class="infobox__grid">
                     @foreach($trainedUsers as $trainedUser)
-                        <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainedUser->user->hash) !!}')">
+                        <div class="infobox__grid-item infobox__grid-item--user">
                             <a href="{{ route('members.show', $trainedUser->user->id) }}">
+                                {!! HTML::memberPhoto($trainer->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
                                 {{ $trainedUser->user->name }}
                             </a>
                             @if ($isTrainerOrAdmin)
@@ -364,10 +365,10 @@ Tools and Equipment
 
                     @foreach($usersPendingInduction as $trainedUser)
                         @if ($isTrainerOrAdmin || $trainedUser->user->id == $user->id)
-                            <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainedUser->user->hash) !!}')" >
+                            <div class="infobox__grid-item infobox__grid-item--user" >
                                 <div>
                                     <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                        {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
+                                        {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
                                         {{ $trainedUser->user->name }}
                                     </a>
                                     

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -27,30 +27,27 @@ Tools and Equipment
     </div>
 </div>
 
-
-
-
-    
 <div class="row">
     <div class="col-sm-12">
         <div class="member-status-bar">
-            @if (!$userInduction)
-                <h4><span class="label label-danger">Training is required</span></h4>
-            @elseif ($userInduction->is_trained)
-                <h4><span class="label label-success">You have been inducted and can use this equipment</span></h4>
-            @elseif ($userInduction)
-                <h4><span class="label label-warning">Training to be completed</span></h4>
+            @if($equipment->requiresInduction())
+                @if (!$userInduction)
+                    <h4><span class="label label-danger">Training is required</span></h4>
+                @elseif ($userInduction->is_trained)
+                    <h4><span class="label label-success">You have been inducted and can use this equipment</span></h4>
+                    @if ($equipment->access_code)
+                        <h4><span class="label label-info">Access code: {{$equipment->access_code}}</span></h4>
+                    @endif
+                @elseif ($userInduction)
+                    <h4><span class="label label-warning">Training to be completed</span></h4>
+                @endif
             @endif
             @if (!$equipment->isWorking())
                 <h4><span class="label label-info">Out of action</span></h4>
             @endif
-            @if ($equipment->access_code)
-                <h4><span class="label label-info">Access code: {{$equipment->access_code}}</span></h4>
-            @endif
             @if ($equipment->dangerous)
                 <h4><span class="label label-danger">Bloody Dangerous</h4>
             @endif
-                    
         </div>
     </div>
 </div>
@@ -92,7 +89,7 @@ Tools and Equipment
                             @endif
 
                             @if ($equipment->trained_instructions)
-                            <h3>Instructions for Use</h3>
+                                <h3>Instructions for Use</h3>
                                 <div class="infobox well">
                                     <p>{!! $equipment->present()->trained_instructions !!}</p>
                                     <br/>
@@ -100,8 +97,8 @@ Tools and Equipment
                             @endif
 
                             @if (in_array($equipment->slug, ['laser', 'laser-1', 'printer-lfp-1', '3dprint-mendel90', '3dprint-mendelmax', 'vac-former-1', 'ultimaker']))
-                                <div style="border-left: 3px solid burlywood; padding-left: 1em;">
-                                    <h4>Pay for usage</h4>
+                                <h3>Pay for usage</h3>
+                                <div class="infobox well">
                                     <p>
                                         Make a payment for your usage of this equipment below.
                                     </p>
@@ -278,18 +275,20 @@ Tools and Equipment
                 <p>These people can train others and maintain the tool - if there's any issues with the tool speak to them.</p>
                 <div class="infobox__grid">
                     @foreach($trainers as $trainer)
-                        <div class="infobox__grid-item">
+                        <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainer->user->hash) !!}')">
                             <a href="{{ route('members.show', $trainer->user->id) }}">
                                 {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
                             </a>
                             {{ $trainer->user->name }}
-                            @if ($isTrainerOrAdmin)
+                            <div>
+                                @if ($isTrainerOrAdmin)
                                 {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainer->user->id, $trainer->id])) !!}
                                 {!! Form::hidden('not_trainer', '1') !!}
                                 {!! Form::hidden('slug', $equipment->slug) !!}
-                                {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
+                                {!! Form::submit('❌', array('class'=>'btn btn-default btn-sm')) !!}
                                 {!! Form::close() !!}
-                            @endif
+                                @endif
+                            </div>
                         </div>
                     @endforeach
                 </div>
@@ -312,26 +311,25 @@ Tools and Equipment
                 <p>There are currently <strong>{{ count($trainedUsers) }}</strong> members who are trained to use this tool.</p>
                 <div class="infobox__grid">
                     @foreach($trainedUsers as $trainedUser)
-                        <div class="infobox__grid-item">
+                        <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainedUser->user->hash) !!}')">
                             <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
                                 {{ $trainedUser->user->name }}
                             </a>
                             @if ($isTrainerOrAdmin)
-                                {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                                {!! Form::hidden('mark_untrained', '1') !!}
-                                {!! Form::hidden('slug', $equipment->slug) !!}
-                                {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
-                                {!! Form::close() !!}
+                                <div>
+                                    {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                    {!! Form::hidden('mark_untrained', '1') !!}
+                                    {!! Form::hidden('slug', $equipment->slug) !!}
+                                    {!! Form::submit('❌', array('class'=>'btn btn-default btn-sm')) !!}
+                                    {!! Form::close() !!}
 
-                                {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                                {!! Form::hidden('is_trainer', '1') !!}
-                                {!! Form::hidden('slug', $equipment->slug) !!}
-                                {!! Form::submit('🎓', array('class'=> $trainedUser->is_trainer ? 'btn btn-xs disabled' : 'btn btn-xs btn-default')) !!}
-                                {!! Form::close() !!}
-                            
+                                    {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                    {!! Form::hidden('is_trainer', '1') !!}
+                                    {!! Form::hidden('slug', $equipment->slug) !!}
+                                    {!! Form::submit('🎓', array('class'=> $trainedUser->is_trainer ? 'btn btn-sm disabled' : 'btn btn-sm btn-default')) !!}
+                                    {!! Form::close() !!}
+                                </div>
                             @endif
-
                         </div>
                     @endforeach
                 </div>
@@ -362,31 +360,33 @@ Tools and Equipment
                                 <p>To get trained, ask on the forum or on Telegram.</p>
                             @endif
                         </div>
-                        <div></div>
                     @endif
 
                     @foreach($usersPendingInduction as $trainedUser)
                         @if ($isTrainerOrAdmin || $trainedUser->user->id == $user->id)
-                            <div class="infobox__grid-item">
-                                <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                    {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
-                                    {{ $trainedUser->user->name }}
-                                </a>
-                                
-                                ({{ $trainedUser->created_at->diff($now)->format("%yy, %mm, %dd") }})
-                                
+                            <div class="infobox__grid-item infobox__grid-item--user" style="background-image:url('{!! \BB\Helpers\UserImage::thumbnailUrl($trainedUser->user->hash) !!}')" >
+                                <div>
+                                    <a href="{{ route('members.show', $trainedUser->user->id) }}">
+                                        {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
+                                        {{ $trainedUser->user->name }}
+                                    </a>
+                                    
+                                    ({{ $trainedUser->created_at->diff($now)->format("%yy, %mm, %dd") }})
+                                </div>
                                 @if ($isTrainerOrAdmin )
-                                    {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
-                                    {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
-                                    {!! Form::hidden('slug', $equipment->slug) !!}
-                                    {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
-                                    {!! Form::close() !!}
-                                    {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                                    {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
-                                    {!! Form::hidden('mark_trained', '1') !!}
-                                    {!! Form::hidden('slug', $equipment->slug) !!}
-                                    {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
-                                    {!! Form::close() !!}
+                                    <div>
+                                        {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
+                                        {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
+                                        {!! Form::hidden('slug', $equipment->slug) !!}
+                                        {!! Form::submit('❌', array('class'=>'btn btn-default btn-sm')) !!}
+                                        {!! Form::close() !!}
+                                        {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                        {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
+                                        {!! Form::hidden('mark_trained', '1') !!}
+                                        {!! Form::hidden('slug', $equipment->slug) !!}
+                                        {!! Form::submit('✔️', array('class'=>'btn btn-default btn-sm')) !!}
+                                        {!! Form::close() !!}
+                                    </div>
                                 @endif
                             </div>
                         @endif
@@ -398,7 +398,7 @@ Tools and Equipment
                             {!! Form::open(array('method'=>'POST', 'route' => ['equipment_training.create'])) !!}
                             {!! Form::select('user_id', [''=>'Add a member']+$memberList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
                             {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
+                            {!! Form::submit('✔️', array('class'=>'btn btn-default btn-sm')) !!}
                             {!! Form::close() !!}
                         </div>
                     @endif

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -277,7 +277,7 @@ Tools and Equipment
                     @foreach($trainers as $trainer)
                         <div class="infobox__grid-item infobox__grid-item--user">
                             <a href="{{ route('members.show', $trainer->user->id) }}">
-                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, 'hidden-sm') !!}
+                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, 'hidden-sm hidden-xs') !!}
                             </a>
                             {{ $trainer->user->name }}
                             <div>
@@ -313,7 +313,7 @@ Tools and Equipment
                     @foreach($trainedUsers as $trainedUser)
                         <div class="infobox__grid-item infobox__grid-item--user">
                             <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
+                                {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm hidden-xs') !!}
                                 {{ $trainedUser->user->name }}
                             </a>
                             @if ($isTrainerOrAdmin)
@@ -368,7 +368,7 @@ Tools and Equipment
                             <div class="infobox__grid-item infobox__grid-item--user" >
                                 <div>
                                     <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                        {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
+                                        {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm hidden-xs') !!}
                                         {{ $trainedUser->user->name }}
                                     </a>
                                     

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -313,7 +313,7 @@ Tools and Equipment
                     @foreach($trainedUsers as $trainedUser)
                         <div class="infobox__grid-item infobox__grid-item--user">
                             <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                                {!! HTML::memberPhoto($trainer->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
+                                {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, 'hidden-sm') !!}
                                 {{ $trainedUser->user->name }}
                             </a>
                             @if ($isTrainerOrAdmin)

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -23,23 +23,187 @@ Tools and Equipment
 
 <div class="row">
     <div class="col-sm-12">
+        <h2>{{ $equipment->name }}</h2>
+    </div>
+</div>
+
+
+
+
+    
+<div class="row">
+    <div class="col-sm-12">
+        <div class="member-status-bar">
+            @if (!$userInduction)
+                <h4><span class="label label-danger">Training is required</span></h4>
+            @elseif ($userInduction->is_trained)
+                <h4><span class="label label-success">You have been inducted and can use this equipment</span></h4>
+            @elseif ($userInduction)
+                <h4><span class="label label-warning">Training to be completed</span></h4>
+            @endif
+            @if (!$equipment->isWorking())
+                <h4><span class="label label-info">Out of action</span></h4>
+            @endif
+            @if ($equipment->access_code)
+                <h4><span class="label label-info">Access code: {{$equipment->access_code}}</span></h4>
+            @endif
+            @if ($equipment->dangerous)
+                <h4><span class="label label-danger">Bloody Dangerous</h4>
+            @endif
+                    
+        </div>
+    </div>
+</div>
+
+<div class="row">
+    <div class="col-sm-12">
         <div class="well">
             <div class="row">
                 <div class="col-sm-6">
-                    <h2>{{ $equipment->name }}</h2>
-                    @if ($equipment->requiresInduction())<b style="color:red">⚠️ Induction required</b><br /> @endif
-                    @if ($equipment->present()->livesIn) 🏠 Lives in: {{ $equipment->present()->livesIn }}<br />@endif
-                    @if ($equipment->present()->manufacturerModel) 🔧 Make: {{ $equipment->present()->manufacturerModel }}<br />@endif
-                    @if ($equipment->present()->purchaseDate) Purchased: {{ $equipment->present()->purchaseDate }}<br />@endif
-                    @if ($equipment->hasUsageCharge())
-                        💵 Usage Cost: {{ $equipment->present()->usageCost }}<br />
+
+                    @if ($equipment->requiresInduction())
+                        @if (!$userInduction)
+                            <div class="well infobox">
+                                <h3>This tool requires an induction</h3>
+                                <ul>
+                                    <li>An induction is required before you may use this tool.</li>
+                                    <li>Inductions are given by other members, request an induction for details on next steps.</li>
+                                    <li>The access fee, if any, goes towards equipment maintenance.</li>
+                                    <li><strong>Equipment access fee: {{ $equipment->present()->accessFee }}</strong></li>
+                                </ul>
+                                
+                                @if(Auth::user()->online_only)
+                                <h4>Online Only users may not use tools or request inductions.</h4>
+                                @else
+                                <div class="paymentModule" data-reason="induction" data-display-reason="Equipment Access Fee" data-button-label="{{ $equipment->access_fee == 0 ? 'Request Free Induction' : 'Pay Induction Fee' }}" data-methods="balance" data-amount="{{ $equipment->access_fee }}" data-ref="{{ $equipment->induction_category }}"></div>
+                                @endif
+                            </div>
+                        @endif
                     @endif
-                    @if ($equipment->isManagedByGroup())
-                        🤗 Managed By: <a href="{{ route('groups.show', $equipment->role->name) }}">{{ $equipment->role->title }}</a>
-                    @endif
-                    @if ($equipment->isPermaloan())<h4><span class="label label-warning">Permaloan</span></h4>@endif
-                    @if (!$equipment->isWorking())<h4><span class="label label-danger">Out of action</span></h4>@endif
                     
+                    @if ($userInduction)
+                        @if ($userInduction->is_trained)
+                            @if ($userInduction->is_trainer && $equipment->trainer_instructions)
+                                <h3>Trainer Instructions</h3>
+                                <div class="infobox well">
+                                    <p>{!! $equipment->present()->trainer_instructions !!}</p>
+                                    <br/>
+                                </div>
+                            @endif
+
+                            @if ($equipment->trained_instructions)
+                            <h3>Instructions for Use</h3>
+                                <div class="infobox well">
+                                    <p>{!! $equipment->present()->trained_instructions !!}</p>
+                                    <br/>
+                                </div>
+                            @endif
+
+                            @if (in_array($equipment->slug, ['laser', 'laser-1', 'printer-lfp-1', '3dprint-mendel90', '3dprint-mendelmax', 'vac-former-1', 'ultimaker']))
+                                <div style="border-left: 3px solid burlywood; padding-left: 1em;">
+                                    <h4>Pay for usage</h4>
+                                    <p>
+                                        Make a payment for your usage of this equipment below.
+                                    </p>
+
+                                    <div class="paymentModule" data-reason="equipment-fee" data-display-reason="Usage Fee" data-button-label="Pay Now" data-methods="balance" data-ref="{{ $equipment->slug }}"></div>
+                                </div>
+                            @endif
+                        @else
+                            @if ($equipment->induction_instructions)
+                                <h3>🔴 Training Next Steps</h3>
+                                <div class="infobox well">
+                                    {!! $equipment->present()->induction_instructions !!}
+                                </div>
+                            @endif
+                        @endif
+                    @endif
+
+                    <div class="tool-info">
+                        @if ($equipment->present()->livesIn)
+                            <div class="tool-info__detail">
+                                <div class="tool-info__key">
+                                    Lives in
+                                </div>
+                                <div class="tool-info__value">
+                                    🏠 {{ $equipment->present()->livesIn }}
+                                </div>
+                            </div>
+                        @endif
+
+                        @if ($equipment->isManagedByGroup())
+                            <div class="tool-info__detail">
+                                <div class="tool-info__key">
+                                    Managed by
+                                </div>
+                                <div class="tool-info__value">
+                                    🤗 <a href="{{ route('groups.show', $equipment->role->name) }}">{{ $equipment->role->title }}</a>
+                                </div>
+                            </div>
+                        @endif
+                        
+                        <div class="tool-info__detail">
+                            <div class="tool-info__key">
+                                Tool working?
+                            </div>
+                            <div class="tool-info__value">
+                                {{ $equipment->isWorking() ? "🟢 Yes" : "🔴 No" }}
+                            </div>
+                        </div>
+                        
+                        <div class="tool-info__detail">
+                            <div class="tool-info__key">
+                                Induction required?
+                            </div>
+                            <div class="tool-info__value">
+                                {{ $equipment->requiresInduction() ? "🔴 Yes" : "🟢 No" }}
+                            </div>
+                        </div>
+                        
+                        @if ($equipment->present()->manufacturerModel)
+                            <div class="tool-info__detail">
+                                <div class="tool-info__key">
+                                    Manufacturer Model
+                                </div>
+                                <div class="tool-info__value">
+                                    🔧 {{ $equipment->present()->manufacturerModel }}
+                                </div>
+                            </div>
+                        @endif
+                        
+                        @if ($equipment->present()->purchaseDate)
+                            <div class="tool-info__detail">
+                                <div class="tool-info__key">
+                                    Purchase Date
+                                </div>
+                                <div class="tool-info__value">
+                                    📅 {{ $equipment->present()->purchaseDate }}
+                                </div>
+                            </div>
+                        @endif
+                      
+                        <div class="tool-info__detail">
+                            <div class="tool-info__key">
+                                Usage Cost
+                            </div>
+                            <div class="tool-info__value">
+                                💸 {{ $equipment->hasUsageCharge() ? $equipment->present()->usageCost : "No usage charge" }}    
+                            </div>
+                        </div>
+                    
+
+                        <div class="tool-info__detail">
+                            <div class="tool-info__key">
+                                Is permaloan?
+                            </div>
+                            <div class="tool-info__value">
+                                {{ $equipment->isPermaloan() ? "🟢 Yes" : "🔴 No" }}    
+                            </div>
+                        </div>
+                        
+                    </div>
+                </div>
+                <div class="col-sm-6">
                     @if ($equipment->isDangerous())
                         <div style="padding: 1em;
                             color: white;
@@ -50,6 +214,13 @@ Tools and Equipment
                             ">
                             This Tool Is Bloody Dangerous
                         </div>
+                    @endif
+                    <h3>Personal Protective Equipment</h3>
+                    @if(strlen($equipment->present()->ppe) > 20)
+                        <p>The following PPE is required</p>
+                        {!! $equipment->present()->ppe !!}
+                    @else
+                        <p>No specific PPE is required. You must still be aware of risks and use relevent PPE to mitigate those risks.</p>
                     @endif
 
                     @if ($equipment->hasPhoto())
@@ -68,194 +239,181 @@ Tools and Equipment
                                 </div>
                             </div>
                         @endfor
-                    
-                    @endif
-                </div>
-                <div class="col-sm-6">
-                    @if ($equipment->requiresInduction())
-                            <h3>Induction @if (!$userInduction)required @endif</h3>
-                            @if (!$userInduction)
-                                <p>
-                                ⚠️ An induction is required before you may use this tool. The access fee goes towards equipment maintenance.<br />
-                                <strong>Equipment access fee: {{ $equipment->present()->accessFee }}</strong><br />
-                                </p>
-    
-                                @if(Auth::user()->online_only)
-                                    <h4>Online Only users may not sign up for tools</h4>
-                                @else
-                                    <div class="paymentModule" data-reason="induction" data-display-reason="Equipment Access Fee" data-button-label="{{ $equipment->access_fee == 0 ? 'Book Free Induction' : 'Pay Induction Fee' }}" data-methods="balance" data-amount="{{ $equipment->access_fee }}" data-ref="{{ $equipment->induction_category }}"></div>
-                                @endif
-    
-                            @elseif ($userInduction->is_trained)
-                                <h4>
-                                    <span class="label label-success">You have been inducted and can use this equipment</span>
-                                </h4>
-    
-                            @elseif ($userInduction)
-                                <h4>
-                                    <span class="label label-info">Access fee paid, induction to be completed</span>
-                                </h4>
-                            @endif
-                    @endif
-                    @if ($userInduction)
-                        @if ($userInduction->is_trained)
-                            @if ($userInduction->is_trainer && $equipment->trainer_instructions)
-                                <div style="border-left: 3px solid tomato; padding-left: 1em;">
-                                    <h4>Trainer Instructions</h4>
-                                    <p>{{ $equipment->trainer_instructions }}</p>
-                                    <br/>
-                                </div>
-                            @endif
-
-                            @if ($equipment->trained_instructions)
-                                <div style="border-left: 3px solid green; padding-left: 1em;">
-                                    <h4>Instructions for Use</h4>
-                                    <p>{{ $equipment->trained_instructions }}</p>
-                                    <br/>
-                                </div>
-                            @endif
-
-                            @if (in_array($equipment->slug, ['laser', 'laser-1', 'printer-lfp-1', '3dprint-mendel90', '3dprint-mendelmax', 'vac-former-1', 'ultimaker']))
-                                <div style="border-left: 3px solid burlywood; padding-left: 1em;">
-                                    <h4>Pay for usage</h4>
-                                    <p>
-                                        Make a payment for your usage of this equipment below.
-                                    </p>
-
-                                    <div class="paymentModule" data-reason="equipment-fee" data-display-reason="Usage Fee" data-button-label="Pay Now" data-methods="balance" data-ref="{{ $equipment->slug }}"></div>
-                                </div>
-                            @endif
-                        @else
-                            @if ($equipment->induction_instructions)
-                                <div style="border-left: 3px solid red; padding-left: 1em;">
-                                    <h4>🔴 Induction Next Steps</h4>
-                                    <p>{{ $equipment->induction_instructions }}</p>
-                                    <br/>
-                                </div>
-                            @endif
-                        @endif
                     @endif
                 </div>
             </div>
+            <br>
+            <div class="row">
+                <div class="col-sm-12">
+                    <div class="infobox well">
+                        <h4>Description</h4>
+                        {!! $equipment->present()->description !!}
+                
+                        <br>
+                        @if ($equipment->present()->help_text)
+                        <h4>{{ $equipment->name }} Help</h4>
+                        {!! $equipment->present()->help_text !!}
+                        @endif
+                        
+                        <br>
+                        @if ($equipment->docs)
+                            <h4>Documentation for the {{ $equipment->name }} is available</h4>
+                            <a target="_blank" class="btn btn-success" href="{{ $equipment->docs }}">View documentation</a>
+                        @endif
+                    </div>
 
-            <hr/>
-
-            {!! $equipment->present()->description !!}
-            <br />
-
-            @if ($equipment->help_text || $equipment->docs)
-                <a data-toggle="modal" data-target="#helpModal" href="#" class="btn btn-info">View Documentation and Help</a>
-                <br /><br />
-            @endif
-
-            <h3>Personal Protective Equipment</h3>
-            @if(strlen($equipment->present()->ppe) > 20)
-                <p>The following PPE is required</p>
-                {!! $equipment->present()->ppe !!}
-            @else
-                <p>No specific PPE is required. You must still be aware of risks and use relevent PPE to mitigate those risks.</p>
-            @endif
-
+                </div>    
+            </div>
         </div>
     </div>
-
 </div>
 
 @if ($equipment->requiresInduction())
+    <h2>Member statuses for this tool</h2>
     <div class="row">
-        <div class="col-sm-12 col-md-4">
-            <div class="row">
-            <h3>🎓 Trainers/Maintainers</h3>
-            <p>These people can train others and maintain the tool.</p>
-            <div class="list-group">
-                @foreach($trainers as $trainer)
-                    <div class="list-group-item">
-                        <a href="{{ route('members.show', $trainer->user->id) }}">
-                            {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
-                        </a>
-                        {{ $trainer->user->name }}
-                        @if ($isTrainerOrAdmin)
-                            {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainer->user->id, $trainer->id])) !!}
-                            {!! Form::hidden('not_trainer', '1') !!}
-                            {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
-                            {!! Form::close() !!}
-                        @endif
-                    </div>
+        <div class="col-sm-12">
+            <div class="well">
+                <h3>🎓 Trainers/Maintainers</h3>
 
-                @endforeach
-            </div>
+                <p>These people can train others and maintain the tool - if there's any issues with the tool speak to them.</p>
+                <div class="infobox__grid">
+                    @foreach($trainers as $trainer)
+                        <div class="infobox__grid-item">
+                            <a href="{{ route('members.show', $trainer->user->id) }}">
+                                {!! HTML::memberPhoto($trainer->user->profile, $trainer->user->hash, 25, '') !!}
+                            </a>
+                            {{ $trainer->user->name }}
+                            @if ($isTrainerOrAdmin)
+                                {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainer->user->id, $trainer->id])) !!}
+                                {!! Form::hidden('not_trainer', '1') !!}
+                                {!! Form::hidden('slug', $equipment->slug) !!}
+                                {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
+                                {!! Form::close() !!}
+                            @endif
+                        </div>
+                    @endforeach
+                </div>
+
+                @if($isTrainerOrAdmin)
+                    <a class="btn btn-danger" href="{{ route('notificationemail.equipment', [$equipment->slug, 'trainer']) }}">
+                        📧 Email 
+                    </a>
+                @endif
             </div>
         </div>
+        
+    </div>
     
-        <div class="col-sm-12 col-md-4">
-            <h3>✔️ Trained Users</h3>
-            <p>These people are trained to use this tool</p>
 
-            <div class="list-group">
-                @foreach($trainedUsers as $trainedUser)
-                    <div class="list-group-item">
-                        <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                            {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
-                            {{ $trainedUser->user->name }}
-                        </a>
-                        @if ($isTrainerOrAdmin)
-                            {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                            {!! Form::hidden('mark_untrained', '1') !!}
-                            {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
-                            {!! Form::close() !!}
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="well">
+                <h3>Trained Users</h3>
+                <p>There are currently <strong>{{ count($trainedUsers) }}</strong> members who are trained to use this tool.</p>
+                <div class="infobox__grid">
+                    @foreach($trainedUsers as $trainedUser)
+                        <div class="infobox__grid-item">
+                            <a href="{{ route('members.show', $trainedUser->user->id) }}">
+                                {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
+                                {{ $trainedUser->user->name }}
+                            </a>
+                            @if ($isTrainerOrAdmin)
+                                {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                {!! Form::hidden('mark_untrained', '1') !!}
+                                {!! Form::hidden('slug', $equipment->slug) !!}
+                                {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
+                                {!! Form::close() !!}
 
-                            {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                            {!! Form::hidden('is_trainer', '1') !!}
-                            {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('🎓', array('class'=> $trainedUser->is_trainer ? 'btn btn-xs disabled' : 'btn btn-xs btn-default')) !!}
-                            {!! Form::close() !!}
-                        
-                        @endif
+                                {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                {!! Form::hidden('is_trainer', '1') !!}
+                                {!! Form::hidden('slug', $equipment->slug) !!}
+                                {!! Form::submit('🎓', array('class'=> $trainedUser->is_trainer ? 'btn btn-xs disabled' : 'btn btn-xs btn-default')) !!}
+                                {!! Form::close() !!}
+                            
+                            @endif
 
-                    </div>
-                @endforeach
-            </div>
-        </div>
-        <div class="col-sm-12 col-md-4">
-            <h3>🛂 Awaiting Inductions</h3>
-            <p>People who have requested an induction</p>
-            <div class="list-group">
-                @foreach($usersPendingInduction as $trainedUser)
-                    <div class="list-group-item">
-                        <a href="{{ route('members.show', $trainedUser->user->id) }}">
-                            {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
-                            {{ $trainedUser->user->name }}
-                        </a>
-                        @if ($isTrainerOrAdmin)
-                            {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
-                            {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
-                            {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
-                            {!! Form::close() !!}
-                            {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
-                            {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
-                            {!! Form::hidden('mark_trained', '1') !!}
-                            {!! Form::hidden('slug', $equipment->slug) !!}
-                            {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
-                            {!! Form::close() !!}
-                        @endif
-                    </div>
-                @endforeach
-                @if ($isTrainerOrAdmin)
-                    <div class="list-group-item">
-                        <p>Add a member</p>
-                        {!! Form::open(array('method'=>'POST', 'route' => ['equipment_training.create'])) !!}
-                        {!! Form::select('user_id', [''=>'Add a member']+$memberList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
-                        {!! Form::hidden('slug', $equipment->slug) !!}
-                        {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
-                        {!! Form::close() !!}
-                    </div>
+                        </div>
+                    @endforeach
+                </div>
+
+                @if($isTrainerOrAdmin)
+                    <a class="btn btn-danger" href="{{ route('notificationemail.equipment', [$equipment->slug, 'trained']) }}">
+                        📧 Email 
+                    </a>
                 @endif
             </div>
         </div>
     </div>
+
+    <div class="row">
+        <div class="col-sm-12">
+            <div class="well infobox">
+                <h3>Awaiting Training</h3>
+               
+                <p>There are currently <strong>{{ count($usersPendingInduction) }}</strong> member(s) who are awaiting training for this tool.</p>
+                
+                <div class="infobox__grid">
+                    @if ($userInduction && !$userInduction->is_trained)
+                        <div class="infobox__grid-item infobox__grid-item--header">
+                            <h3>🔴 Training Next Steps</h3>
+                            @if ($equipment->induction_instructions)
+                                {!! $equipment->present()->induction_instructions !!}
+                            @else
+                                <p>To get trained, ask on the forum or on Telegram.</p>
+                            @endif
+                        </div>
+                        <div></div>
+                    @endif
+
+                    @foreach($usersPendingInduction as $trainedUser)
+                        @if ($isTrainerOrAdmin || $trainedUser->user->id == $user->id)
+                            <div class="infobox__grid-item">
+                                <a href="{{ route('members.show', $trainedUser->user->id) }}">
+                                    {!! HTML::memberPhoto($trainedUser->user->profile, $trainedUser->user->hash, 25, '') !!}
+                                    {{ $trainedUser->user->name }}
+                                </a>
+                                
+                                ({{ $trainedUser->created_at->diff($now)->format("%yy, %mm, %dd") }})
+                                
+                                @if ($isTrainerOrAdmin )
+                                    {!! Form::open(array('method'=>'DELETE', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.destroy', $trainedUser->user->id, $trainedUser->id])) !!}
+                                    {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
+                                    {!! Form::hidden('slug', $equipment->slug) !!}
+                                    {!! Form::submit('❌', array('class'=>'btn btn-default btn-xs')) !!}
+                                    {!! Form::close() !!}
+                                    {!! Form::open(array('method'=>'PUT', 'style'=>'display:inline;float:right;', 'route' => ['account.induction.update', $trainedUser->user->id, $trainedUser->id])) !!}
+                                    {!! Form::hidden('trainer_user_id', Auth::user()->id) !!}
+                                    {!! Form::hidden('mark_trained', '1') !!}
+                                    {!! Form::hidden('slug', $equipment->slug) !!}
+                                    {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
+                                    {!! Form::close() !!}
+                                @endif
+                            </div>
+                        @endif
+                    @endforeach
+                    
+                    @if ($isTrainerOrAdmin)
+                        <div class="infobox__grid-item infobox__grid-item--footer">
+                            <p>Add a member</p>
+                            {!! Form::open(array('method'=>'POST', 'route' => ['equipment_training.create'])) !!}
+                            {!! Form::select('user_id', [''=>'Add a member']+$memberList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
+                            {!! Form::hidden('slug', $equipment->slug) !!}
+                            {!! Form::submit('✔️', array('class'=>'btn btn-default btn-xs')) !!}
+                            {!! Form::close() !!}
+                        </div>
+                    @endif
+                </div>
+            
+                @if($isTrainerOrAdmin)
+                    <a class="btn btn-danger" href="{{ route('notificationemail.equipment', [$equipment->slug, 'awaiting_training']) }}">
+                        📧 Email 
+                    </a>
+                @endif
+            </div>
+        </div>
+    </div>
+
+
 @endif
 <br/>
 <div class="row">
@@ -317,34 +475,6 @@ Tools and Equipment
         <?php echo $equipmentLog->render(); ?>
     </div>
     @endif
-
-    <div class="modal fade" id="helpModal">
-        <div class="modal-dialog modal-lg">
-            <div class="modal-content">
-                <div class="modal-header">
-                    <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-                    <h4 class="modal-title">Documentation and Help</h4>
-                </div>
-                <div class="modal-body">
-                    @if ($equipment->present()->help_text)
-                        <h1>{{ $equipment->name }} Help</h1>
-                        <div class="well">
-                            {!! $equipment->present()->help_text !!}
-                        </div>
-                    @endif
-                    
-                    @if ($equipment->docs)
-                        <h1>{{ $equipment->name }} Documentation</h1>
-                        <a target="_blank" class="btn btn-info" href="{{ $equipment->docs }}">➡️ View in full on the documentation system</a>
-                        <br/><br/>
-                        <div class="well alert-info" style="background:#eee">
-                            {!! $docs !!}
-                        </div>
-                    @endif
-                </div>
-            </div>
-        </div>
-    </div>
 
 </div>
 

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -270,7 +270,7 @@ Tools and Equipment
     <div class="row">
         <div class="col-sm-12">
             <div class="well">
-                <h3>🎓 Trainers/Maintainers</h3>
+                <h3>🎓 Trainers</h3>
 
                 <p>These people can train others and maintain the tool - if there's any issues with the tool speak to them.</p>
                 <div class="infobox__grid">

--- a/resources/views/notification_email/tool.blade.php
+++ b/resources/views/notification_email/tool.blade.php
@@ -18,7 +18,7 @@ Email members by training status
             <ul>
                 <li>Awaiting training</li>
                 <li>Trained</li>
-                <li>Trainers/Maintainers</li>
+                <li>Trainers</li>
             </ul>
             <p>It's essential that all communication is strictly tool based, and non-personal. Emails are copied to the board.</p>
         </div>

--- a/resources/views/notification_email/tool.blade.php
+++ b/resources/views/notification_email/tool.blade.php
@@ -1,0 +1,103 @@
+@extends('layouts.main')
+
+@section('meta-title')
+Email members by training status
+@stop
+
+@section('page-title')
+Email members by training status
+@stop
+
+@section('content')
+
+<div class="row">
+    <div class="col-xs-12">
+        <div class="well">
+            <h3>Tool trainers may email people who have a training record</h3>
+            <p>The categories available are:</p>
+            <ul>
+                <li>Awaiting training</li>
+                <li>Trained</li>
+                <li>Trainers/Maintainers</li>
+            </ul>
+            <p>It's essential that all communication is strictly tool based, and non-personal. Emails are copied to the board.</p>
+        </div>
+    </div>
+</div>
+    
+    
+<div class="row">
+    <div class="col-xs-12 col-md-12 col-lg-8">
+        <div class="infobox well">
+            {!! Form::open(array('route' => 'notificationemail.store', 'class'=>'', 'method'=>'POST')) !!}
+
+            <div class="row">
+                <div class="col-xs-12 col-md-9">
+                    <div class="{{ Notification::hasErrorDetail('recipient', 'has-error has-feedback') }}">
+                
+                        <h3>Recipients</h3>
+                        {!! Form::hidden('recipient', "tool/$equipment->slug/$status", null, ['class'=>'form-control']) !!}
+                       
+                        {!! Form::label('equipment', 'Equipment') !!}
+                        <div class="form-control">{{ $equipment->name }} 
+                            (<a href="{{route('equipment.show', [$equipment->slug])}}">
+                                Visit tool
+                            </a>) 
+                        </div>
+                        
+                        {!! Form::label('status', 'Training Status') !!}
+                        <div class="form-control">{{ $statuses[$status] }}</div>
+                         
+                        {!! Notification::getErrorDetail('recipient') !!}
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-xs-12 col-md-9">
+                    <div class="{{ Notification::hasErrorDetail('subject', 'has-error has-feedback') }}">
+                        <h3>Subject</h3>
+                        {!! Form::text('subject', null, ['class'=>'form-control']) !!}
+                        {!! Notification::getErrorDetail('subject') !!}
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-xs-12 col-md-9">
+                    <div class="form-group {{ Notification::hasErrorDetail('message', 'has-error has-feedback') }}">
+                        
+                        <h3>Message</h3>
+                        <p>Do not draft messages here, this form does not save drafts on page refreshes.</p>
+                        <p>The email will be addressed to the user (e.g. Hi User), and contain the standard signature, the message above will be placed in between</p>
+                        {!! Form::textarea('message', null, ['class'=>'form-control']) !!}
+                        {!! Notification::getErrorDetail('message') !!}
+                    </div>
+                </div>
+            </div>
+
+            <div class="row">
+                <div class="col-xs-12">
+                    <p>
+                        <b>Important!</b><br>
+                        <ul>
+                            <li>The message will be sent as soon as you click send.</li>
+                            <li>If you do not tick the checkbox, it will only go to you</li>
+                            <li>Be sure to copy the message if you're writing a draft, as the message won't reappear once the page loads</li>
+                            </ul>
+                    </p>
+                    <p>To actually send the email to everyone, make sure to tick the checkbox below.</p>
+
+                        {!! Form::checkbox('send_to_all') !!}
+                        {!! Form::label('send_to_all', 'Send the message to everyone, not just yourself') !!}<br>
+                    {!! Form::submit('Send', array('class'=>'btn btn-primary')) !!}<br>
+                </div>
+            </div>
+
+            {!! Form::close() !!}
+        </div>
+    </div>
+</div>
+
+
+@stop


### PR DESCRIPTION
## Summary
* Tidy up tool page, both the form and the layout
* Dedicated access code field for showing in the status bar
* Make important information more obvious
* Email button for statuses
* Ability for trainers or admins to email members waiting for inductions without exposing email addresses

## Screenshots

### Tool page
![localhost_3000_equipment_laser (1)](https://github.com/HACManchester/membership-system/assets/905676/c4f51a50-0036-49da-b0f8-c7e98a2517a4)

### Form for tool page updated
![localhost_3000_equipment_laser_edit](https://github.com/HACManchester/membership-system/assets/905676/05c673f7-1b1e-4b82-a3f9-7cedd201a34f)

### If you are an admin, or a trainer for a tool, you'll see new buttons:
<img width="1143" alt="image" src="https://github.com/HACManchester/membership-system/assets/905676/a3437acd-6312-484f-ba3a-478c7b47aa35">


### If pressed, they take you to a page where you can enter an email
![localhost_3000_notification_email_equipment_laser_status_trained](https://github.com/HACManchester/membership-system/assets/905676/7a6e55c8-3cd3-4ee3-8169-526dd28a6b8a)


### This sends emails in this template
<img width="1126" alt="image" src="https://github.com/HACManchester/membership-system/assets/905676/1b6bab05-b88d-4642-b5ee-9dc824771c40">

