### PR TITLE
remove old logic from keycode store method

### DIFF
--- a/app/Http/Controllers/KeyFobController.php
+++ b/app/Http/Controllers/KeyFobController.php
@@ -44,10 +44,6 @@ class KeyFobController extends Controller
         //If the fob begins with ff it's a request for an access code
         //Bin off any extra characters
         if(substr( $input['key_id'], 0, 2 ) === "ff"){
-            // Don't allow users to set up a keycode if they don't have an access method (i.e. fob)
-            if(\Auth::user()->keyFobs()->count() == 0){
-                throw new \BB\Exceptions\AuthenticationException();
-            }
 
             // generate random access code, if there's a collision, it'll fail due to db constraints
             $input['key_id']="ff".rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9).rand(0,9);


### PR DESCRIPTION
This removes logic which stops someone adding a pin code if they don't have a fob.
This logic was temporary until we got the induction code set up