### PR TITLE
Fix memberships not ending due to payment failures

### DIFF
--- a/app/Console/Commands/CreateTodaysSubCharges.php
+++ b/app/Console/Commands/CreateTodaysSubCharges.php
@@ -51,13 +51,15 @@ class CreateTodaysSubCharges extends Command
 
         $this->subscriptionChargeService->createSubscriptionCharges($targetDate);
 
-        //in case yesterdays process failed we will rerun the past seven days, this should pickup any stragglers
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-1 day
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-2 days
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-3 days
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-4 days
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-5 days
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-6 days
-        $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-7 days
+        // TODO: Rebuild a better way of catching stragglers. This can result in multiple, duplicate, attempts to charge
+
+        // in case yesterdays process failed we will rerun the past seven days, this should pickup any stragglers
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-1 day
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-2 days
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-3 days
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-4 days
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-5 days
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-6 days
+        // $this->subscriptionChargeService->createSubscriptionCharges($targetDate->subDay()); //-7 days
     }
 }

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -340,11 +340,7 @@ class User extends Model implements AuthenticatableContract, CanResetPasswordCon
 
     public function scopeActive($query)
     {
-        return $query
-            ->whereActive(true)
-            ->where('payment_method', '!=', '')
-            ->where('subscription_expires', '>=', date('Y-m-d'))
-            ->where('monthly_subscription', '>', 0);
+        return $query->whereActive(true);
     }
 
     public function scopeNotSpecialCase($query)

--- a/app/Helpers/GoCardlessHelper.php
+++ b/app/Helpers/GoCardlessHelper.php
@@ -77,14 +77,10 @@ class GoCardlessHelper
      * @param             $amount
      * @param null|string $name
      * @param null|string $description
-     * @return bool|mixed
+     * @return \GoCardlessPro\Resources\Payment
      */
     public function newBill($mandateId, $amount, $name = null, $description = null)
     {
-        // If the total is above £50 something probably isn't right
-        if ($amount > (50 * 100)) {
-            throw new \Exception("Attempting a DD charge for over £50");
-        }
         try {
             return $this->client->payments()->create([
                 "params" => [
@@ -103,7 +99,7 @@ class GoCardlessHelper
             ]);
         } catch (\Exception $e) {
             \Log::error($e);
-            return false;
+            throw $e;
         }
     }
 

--- a/app/Process/CheckMemberships.php
+++ b/app/Process/CheckMemberships.php
@@ -38,6 +38,7 @@ class CheckMemberships
 
             $cutOffDate = MembershipPayments::getSubGracePeriodDate($user->payment_method);
             if ( ! $user->subscription_expires || $user->subscription_expires->lt($cutOffDate)) {
+                // TODO: Send email warning members who've fallen within the grace period?
                 $expired = true;
             }
 

--- a/app/Process/CheckMemberships.php
+++ b/app/Process/CheckMemberships.php
@@ -28,8 +28,7 @@ class CheckMemberships
 
     public function run()
     {
-
-        $users = User::active()->where('status', '=', 'active')->notSpecialCase()->get();
+        $users = User::active()->notSpecialCase()->get();
         $members = [];
 
         foreach ($users as $user) {

--- a/app/Services/MemberSubscriptionCharges.php
+++ b/app/Services/MemberSubscriptionCharges.php
@@ -9,6 +9,9 @@ use BB\Repo\PaymentRepository;
 use BB\Repo\SubscriptionChargeRepository;
 use BB\Repo\UserRepository;
 use Carbon\Carbon;
+use Exception;
+use GoCardlessPro\Core\Exception\InvalidStateException;
+use GoCardlessPro\Core\Exception\ValidationFailedException;
 
 class MemberSubscriptionCharges
 {
@@ -131,23 +134,41 @@ class MemberSubscriptionCharges
 
         //Charge the gocardless users
         $members = [];
+        $membersWeCouldntBill = [];
         foreach ($goCardlessUsers as $charge) {
             $amount = $charge->user->monthly_subscription;
-            $bill = $this->goCardless->newBill($charge->user->mandate_id, ($amount * 100), $this->goCardless->getNameFromReason('subscription'));
-            if ($bill) {
-                array_push($members, $charge->user->name);
+            try {
+                $bill = $this->goCardless->newBill($charge->user->mandate_id, ($amount * 100), $this->goCardless->getNameFromReason('subscription'));
+                $members[] = $charge->user->name;
                 $status = $bill->status;
                 if ($status == 'pending_submission') {
                     $status = 'pending';
                 }
-                $this->paymentRepository->recordSubscriptionPayment($charge->user->id, 'gocardless-variable', $bill->id, $amount, $status, 0, $charge->id);
             }
+            catch (InvalidStateException | ValidationFailedException $e) {
+                // TODO: Notify member somehow? If not, they'll eventually be picked up by CheckMemberships
+                $status = 'failed';
+                $membersWeCouldntBill[] = $charge->user->name;
+            }
+            catch (Exception $e) {
+                $status = 'error';
+                $membersWeCouldntBill[] = $charge->user->name;
+            }
+
+            $this->paymentRepository->recordSubscriptionPayment($charge->user->id, 'gocardless-variable', $bill->id, $amount, $status, 0, $charge->id);
         };
 
         $this->telegramHelper->notify(
-            TelegramHelper::JOB, 
+            TelegramHelper::JOB,
             "Created bills for: " . implode(", ", $members)
         );
+
+        if (count($membersWeCouldntBill) > 0) {
+            $this->telegramHelper->notify(
+                TelegramHelper::JOB,
+                "Could not create bills for: " . implode(", ", $members)
+            );
+        }
     }
 
 

--- a/resources/views/account/partials/payment-problem-panel.blade.php
+++ b/resources/views/account/partials/payment-problem-panel.blade.php
@@ -27,7 +27,7 @@
                         Your latest subscription payment has failed and your account has been temporarily suspended.<br />
                         You can retry your payment now.
 
-                        <div class="paymentModule" data-reason="subscription" data-display-reason="Retry payment" data-methods="gocardless,stripe,balance" data-amount="{{ $user->monthly_subscription }}"></div>
+                        <div class="paymentModule" data-reason="subscription" data-display-reason="Retry payment" data-methods="gocardless,balance" data-amount="{{ $user->monthly_subscription }}"></div>
 
                         @if (Auth::user()->isAdmin())
                             <small>Admins: You cannot do this process on behalf of the member, it will just charge your account.</small>

--- a/resources/views/emails/suspended.blade.php
+++ b/resources/views/emails/suspended.blade.php
@@ -11,7 +11,7 @@
     Your latest subscription payment has failed to process and we need you to login and retry your payment or make a manual payment.
 </p>
 <p>
-    While your membership is suspended you wont have access to Hackspace Manchester and if you have one your key fob wont work.
+    While your membership is suspended you wont have access to Hackspace Manchester.
 </p>
 <p>
     Please login as soon as you can and make your subscription payment.<br />


### PR DESCRIPTION
Root problem here was `User::scopeActive` being updated to only return memberships expiring now or in the future, whereas `CheckMemberships` depended upon it returning recently-expired subscriptions – so it could actually process them and end them.

The first commit here solves that issue.

The second commit introduces more explicit exception handling, and formally records failed or errored payments on-site for users and admins to see alike. This can be further improved to eagerly send payment warnings or end memberships, but that's not something to dig into today.