### PR TITLE
Remove ability to pay for equipment inductions & usage via the on-site balance feature

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,7 @@ SSO_KEY=
 # For Telegram notifications
 TELEGRAM_BOT_KEY=
 TELEGRAM_BOT_CHAT=
+TELEGRAM_NOTIFICATIONS_DISABLED=true
 
 # For integration with Pi-based space access control
 QUERY2_ACCESS_KEY=

--- a/app/Entities/Induction.php
+++ b/app/Entities/Induction.php
@@ -45,9 +45,6 @@ class Induction extends Model
     protected $attributes = [
         'active' => false,
         'is_trainer' => false,
-
-        // TODO: Make these nullable?
-        'trainer_user_id' => 0,
     ];
 
     protected $casts = [
@@ -72,25 +69,8 @@ class Induction extends Model
         return $this->belongsTo('\BB\Entities\User');
     }
 
-    public static function findExisting($userId, $key)
-    {
-        return self::where('user_id', $userId)->where('key', $key)->first();
-    }
-
     public static function trainersFor($key)
     {
         return self::where('key', $key)->where('is_trainer', 1)->get();
-    }
-
-    public static function trainersForDropdown($key)
-    {
-        $trainers = self::trainersFor($key);
-        $trainersArray = [null => 'Unknown'];
-
-        foreach ($trainers as $trainer) {
-            $trainersArray[$trainer->user->id] = $trainer->user->name;
-        }
-
-        return $trainersArray;
     }
 }

--- a/app/Entities/Induction.php
+++ b/app/Entities/Induction.php
@@ -36,8 +36,6 @@ class Induction extends Model
     protected $fillable = [
         'key',
         'user_id',
-        'paid',
-        'payment_id',
         'trained',
         'active',
         'is_trainer',
@@ -46,11 +44,9 @@ class Induction extends Model
 
     protected $attributes = [
         'active' => false,
-        'paid' => false,
         'is_trainer' => false,
 
         // TODO: Make these nullable?
-        'payment_id' => 0,
         'trainer_user_id' => 0,
     ];
 
@@ -66,12 +62,6 @@ class Induction extends Model
     }
 
 
-    public function getIsTrainedAttribute()
-    {
-        return (! empty($this->trained));
-    }
-
-
     public function user()
     {
         return $this->belongsTo('\BB\Entities\User');
@@ -80,11 +70,6 @@ class Induction extends Model
     public function trainerUser()
     {
         return $this->belongsTo('\BB\Entities\User');
-    }
-
-    public function payment()
-    {
-        return $this->belongsTo('\BB\Entities\Payment');
     }
 
     public static function findExisting($userId, $key)

--- a/app/Entities/Induction.php
+++ b/app/Entities/Induction.php
@@ -1,4 +1,6 @@
-<?php namespace BB\Entities;
+<?php
+
+namespace BB\Entities;
 
 
 use Illuminate\Database\Eloquent\Model;
@@ -26,19 +28,36 @@ class Induction extends Model
      */
     protected $hidden = array();
 
-
     /**
      * Fillable fields
      *
      * @var array
      */
     protected $fillable = [
-        'key', 'user_id', 'paid', 'payment_id', 'trained', 'active'
+        'key',
+        'user_id',
+        'paid',
+        'payment_id',
+        'trained',
+        'active',
+        'is_trainer',
+        'trainer_user_id'
     ];
 
-
     protected $attributes = [
+        'active' => false,
+        'paid' => false,
+        'is_trainer' => false,
 
+        // TODO: Make these nullable?
+        'payment_id' => 0,
+        'trainer_user_id' => 0,
+    ];
+
+    protected $casts = [
+        'paid' => 'boolean',
+        'active' => 'boolean',
+        'is_trainer' => 'boolean',
     ];
 
     public function getDates()
@@ -49,7 +68,7 @@ class Induction extends Model
 
     public function getIsTrainedAttribute()
     {
-        return ( ! empty($this->trained));
+        return (! empty($this->trained));
     }
 
 
@@ -81,7 +100,7 @@ class Induction extends Model
     public static function trainersForDropdown($key)
     {
         $trainers = self::trainersFor($key);
-        $trainersArray = [null=>'Unknown'];
+        $trainersArray = [null => 'Unknown'];
 
         foreach ($trainers as $trainer) {
             $trainersArray[$trainer->user->id] = $trainer->user->name;

--- a/app/Handlers/PaymentEventHandler.php
+++ b/app/Handlers/PaymentEventHandler.php
@@ -67,13 +67,6 @@ class PaymentEventHandler
 
             $this->recordDoorKeyPaymentId($userId, $paymentId);
 
-        } elseif ($reason == 'storage-box') {
-
-
-        } elseif ($reason == 'equipment-fee') {
-
-            $this->updateBalance($userId);
-
         } elseif ($reason == 'costs') {
 
             $this->updateBalance($userId);

--- a/app/Handlers/PaymentEventHandler.php
+++ b/app/Handlers/PaymentEventHandler.php
@@ -63,10 +63,6 @@ class PaymentEventHandler
 
             $this->updateSubPayment($paymentId, $userId, $status);
 
-        } elseif ($reason == 'induction') {
-
-            $this->createInductionRecord($userId, $ref, $paymentId);
-
         } elseif ($reason == 'door-key') {
 
             $this->recordDoorKeyPaymentId($userId, $paymentId);
@@ -99,9 +95,6 @@ class PaymentEventHandler
     {
         if (($source == 'balance') || ($reason == 'balance')) {
             $this->updateBalance($userId);
-        }
-        if ($reason == 'induction') {
-
         }
 
         if ($reason == 'storage-box') {
@@ -186,19 +179,6 @@ class PaymentEventHandler
         if ($payment->amount != $subCharge->amount) {
             $this->subscriptionChargeRepository->updateAmount($subCharge->id, $payment->amount);
         }
-    }
-
-    private function createInductionRecord($userId, $ref, $paymentId)
-    {
-        /* @TODO: Replace with a repo */
-        /* @TODO: Verify payment amount is valid - this could have been changed */
-        $induction = Induction::create([
-            'user_id' => $userId,
-            'key' => $ref,
-            'paid' => true,
-            'payment_id' => $paymentId
-        ]);
-        \Event::dispatch(new InductionRequestedEvent($induction));
     }
 
     private function recordDoorKeyPaymentId($userId, $paymentId)

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -260,6 +260,7 @@ class AccountController extends Controller
 
         $inductions = $this->equipmentRepository->getRequiresInduction();
 
+        // todo: make these variable names make sense
         $userInductions = $user->inductions()->get();
         foreach ($inductions as $i=>$induction) {
             $inductions[$i]->userInduction = false;

--- a/app/Http/Controllers/GoCardlessPaymentController.php
+++ b/app/Http/Controllers/GoCardlessPaymentController.php
@@ -128,47 +128,9 @@ class GoCardlessPaymentController extends Controller
         }
     }
 
-
-
-    private function getDescription($reason)
-    {
-        if ($reason == 'subscription') {
-            return "Monthly Subscription Fee - Manual";
-        } elseif ($reason == 'induction') {
-            return strtoupper(\Request::input('induction_key')) . " Induction Fee";
-        } elseif ($reason == 'door-key') {
-            return "Door Key Deposit";
-        } elseif ($reason == 'storage-box') {
-            return "Storage Box Deposit";
-        } elseif ($reason == 'balance') {
-            return "BB Credit Payment";
-        } else {
-            throw new \BB\Exceptions\NotImplementedException();
-        }
-    }
-
-    private function getName($reason, $userId)
-    {
-        if ($reason == 'subscription') {
-            return strtoupper("BBSUB" . $userId . ":MANUAL");
-        } elseif ($reason == 'induction') {
-            return strtoupper("BBINDUCTION" . $userId . ":" . \Request::get('induction_key'));
-        } elseif ($reason == 'door-key') {
-            return strtoupper("BBDOORKEY" . $userId);
-        } elseif ($reason == 'storage-box') {
-            return strtoupper("BBSTORAGEBOX" . $userId);
-        } elseif ($reason == 'balance') {
-            return strtoupper("BBBALANCE" . $userId);
-        } else {
-            throw new \BB\Exceptions\NotImplementedException();
-        }
-    }
-
     private function getReference($reason)
     {
-        if ($reason == 'induction') {
-            return \Request::get('ref');
-        } elseif ($reason == 'balance') {
+        if ($reason == 'balance') {
             return \Request::get('reference');
         }
         return false;

--- a/app/Http/Controllers/InductionController.php
+++ b/app/Http/Controllers/InductionController.php
@@ -20,8 +20,6 @@ class InductionController extends Controller
         $induction = Induction::create([
             'user_id' => $userId,
             'key' => $equipment->induction_category,
-            'paid' => true,
-            'payment_id' => 0
         ]);
 
         \Event::dispatch(new InductionRequestedEvent($induction));

--- a/app/Http/Controllers/PaymentController.php
+++ b/app/Http/Controllers/PaymentController.php
@@ -144,29 +144,6 @@ class PaymentController extends Controller
             $user->payments()->save($payment);
 
             $user->extendMembership(\Request::input('source'), \Carbon\Carbon::now()->addMonth());
-        } elseif ($reason == 'induction') {
-            if (\Request::input('source') == 'manual') {
-                $ref = \Request::input('induction_key');
-                ($item = $this->equipmentRepository->findBySlug($ref)) || App::abort(404);
-                $payment = new Payment([
-                    'reason'           => $reason,
-                    'source'           => 'manual',
-                    'source_id'        => '',
-                    'amount'           => $item->cost,
-                    'amount_minus_fee' => $item->cost,
-                    'status'           => 'paid'
-                ]);
-                $payment = $user->payments()->save($payment);
-                $induction = Induction::create([
-                    'user_id'    => $user->id,
-                    'key'        => $ref,
-                    'paid'       => true,
-                    'payment_id' => $payment->id
-                ]);
-                \Event::dispatch(new InductionRequestedEvent($induction));
-            } else {
-                throw new \BB\Exceptions\NotImplementedException();
-            }
         } elseif ($reason == 'door-key') {
             $payment = new Payment([
                 'reason'           => $reason,

--- a/app/Http/Controllers/PaymentOverviewController.php
+++ b/app/Http/Controllers/PaymentOverviewController.php
@@ -37,7 +37,7 @@ class PaymentOverviewController extends Controller
         
 
         $laserCutterInvestment = $this->paymentRepository->getPaymentsByReference('laser-cutter')->sum('amount');
-        $laserCutterMoneySpent = $this->paymentRepository->getEquipmentFeePayments('laser')->sum('amount');
+        $laserCutterMoneySpent = 0;
 
         return \View::make('payment_overview.index')->with(compact('balancePaidIn', 'balancePaidOut', 'balanceLiability', 'storageBoxLiability', 'doorKeyLiability', 'laserCutterInvestment', 'laserCutterMoneySpent'));
     }

--- a/app/Http/Requests/StoreInductionRequest.php
+++ b/app/Http/Requests/StoreInductionRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BB\Http\Requests;
+
+use BB\Entities\Induction;
+use BB\Entities\User;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreInductionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        $userAwaitingTraining = null;
+        if ($this->has('user_id')) {
+            $userAwaitingTraining = User::find($this->input('user_id'));
+        }
+
+        return $this->user()->can('create', [
+            Induction::class,
+            $this->route('equipment'),
+            $userAwaitingTraining
+        ]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'user_id' => ['exists:BB\Entities\User,id'],
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [];
+    }
+}

--- a/app/Http/Requests/TrainInductionRequest.php
+++ b/app/Http/Requests/TrainInductionRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BB\Http\Requests;
+
+use BB\Entities\Induction;
+use Illuminate\Foundation\Http\FormRequest;
+
+class TrainInductionRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->can('train', [Induction::class, $this->route('induction')]);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'trainer_user_id' => ['required', 'exists:BB\Entities\User,id'],
+        ];
+    }
+
+    /**
+     * Get the error messages for the defined validation rules.
+     *
+     * @return array
+     */
+    public function messages()
+    {
+        return [];
+    }
+}

--- a/app/Notifications/ErrorNotification.php
+++ b/app/Notifications/ErrorNotification.php
@@ -46,11 +46,16 @@ class ErrorNotification extends Notification
      */
     public function via($notifiable)
     {
+        if (!config('services.telegram-bot-api.enabled')) {
+            return [];
+        }
+
         return [TelegramChannel::class];
     }
 
     public function toTelegram($notifiable)
     {
+
         $icon = array(
             'error' => '🛑',
             'warn' => '⚠️',

--- a/app/Policies/InductionPolicy.php
+++ b/app/Policies/InductionPolicy.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace BB\Policies;
+
+use BB\Entities\Equipment;
+use BB\Entities\User;
+use BB\Entities\induction;
+use BB\Repo\InductionRepository;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class InductionPolicy
+{
+    use HandlesAuthorization;
+
+    protected $inductionRepository;
+
+    public function __construct(InductionRepository $inductionRepository)
+    {
+        $this->inductionRepository = $inductionRepository;
+    }
+
+    public function before($user, $ability)
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        // fall through to policy methods
+        return null;
+    }
+
+    /**
+     * Determine whether the user can view the induction.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\Induction  $induction
+     * @return mixed
+     */
+    public function view(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $equipment->induction_category);
+    }
+
+    /**
+     * Determine whether the user can create induction.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\Equipment  $Equipment
+     * @param  \BB\Entities\User|null  $userAwaitingTraining
+     * @return mixed
+     */
+    public function create(User $user, Equipment $equipment, $userAwaitingTraining = null)
+    {
+        // Requesting for self
+        if ($userAwaitingTraining === null) {
+            return true;
+        }
+
+        // Requesting for others
+        return $this->inductionRepository->isTrainerForEquipment($user, $equipment->induction_category);
+    }
+
+    /**
+     * Determine whether the user can mark the inductee as trained.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\induction  $induction
+     * @return mixed
+     */
+    public function train(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $induction->key);
+    }
+
+    /**
+     * Determine whether the user can remove the trained flag from the inductee
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\induction  $induction
+     * @return mixed
+     */
+    public function untrain(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $induction->key);
+    }
+
+    /**
+     * Determine whether the user can promote the inductee as a trainer
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\induction  $induction
+     * @return mixed
+     */
+    public function promote(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $induction->key);
+    }
+
+    /**
+     * Determine whether the user can demote the inductee from being a trainer
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\induction  $induction
+     * @return mixed
+     */
+    public function demote(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $induction->key);
+    }
+
+    /**
+     * Determine whether the user can delete the induction.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\induction  $induction
+     * @return mixed
+     */
+    public function delete(User $user, Induction $induction)
+    {
+        return $this->inductionRepository->isTrainerForEquipment($user, $induction->key);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -6,11 +6,13 @@ namespace BB\Providers;
 
 use BB\Entities\Equipment;
 use BB\Entities\EquipmentArea;
+use BB\Entities\Induction;
 use BB\Entities\KeyFob;
 use BB\Entities\StorageBox;
 use BB\Entities\User;
 use BB\Policies\EquipmentAreaPolicy;
 use BB\Policies\EquipmentPolicy;
+use BB\Policies\InductionPolicy;
 use BB\Policies\KeyFobPolicy;
 use BB\Policies\StorageBoxPolicy;
 use BB\Policies\UserPolicy;
@@ -29,6 +31,7 @@ class AuthServiceProvider extends ServiceProvider
         User::class => UserPolicy::class,
         StorageBox::class => StorageBoxPolicy::class,
         EquipmentArea::class => EquipmentAreaPolicy::class,
+        Induction::class => InductionPolicy::class,
     ];
 
     /**

--- a/app/Repo/InductionRepository.php
+++ b/app/Repo/InductionRepository.php
@@ -24,22 +24,6 @@ class InductionRepository extends DBRepository
         $this->model = $model;
     }
 
-
-    /**
-     * @return array
-     */
-    public function getTrainersByEquipment()
-    {
-        $trainersRaw = $this->model->with('user', 'user.profile')->where('is_trainer', true)->get();
-        $trainers = [];
-        foreach ($trainersRaw as $trainer) {
-            if (isset($trainer->user->name) && $trainer->user->active) {
-                $trainers[$trainer->key][] = $trainer->user;
-            }
-        }
-        return $trainers;
-    }
-
     /**
      * @param $deviceId
      * @return Collection
@@ -64,55 +48,6 @@ class InductionRepository extends DBRepository
             ->count() > 0;
     }
 
-    /**
-     * Get all the users who have been trained on a piece of equipment
-     * @param string $deviceId
-     * @return Collection
-     */
-    public function getUsersForEquipment($deviceId)
-    {
-        $users = new Collection();
-        $inductionUsers = $this->model->with('user')->whereHas('user', function ($q) {
-            $q->where('active', '=', true);
-        })->where('trained', '!=', '')->where('key', $deviceId)->get();
-
-        //Extract the users from the inductions and place into a new collection
-        foreach ($inductionUsers as $inductedUser) {
-            $users->add($inductedUser->user);
-        }
-        return $users;
-    }
-
-
-    /**
-     * @return array
-     */
-    public function getUsersPendingInduction()
-    {
-        $usersRaw = $this->model->with('user', 'user.profile')->whereNull('trained')->get();
-        $users = [];
-        foreach ($usersRaw as $induction) {
-            if (isset($induction->user->name) && $induction->user->active) {
-                $users[$induction->key][] = $induction->user;
-            }
-        }
-        return $users;
-    }
-
-    /**
-     * @return array
-     */
-    public function getTrainedUsers()
-    {
-        $usersRaw = $this->model->with('user', 'user.profile')->whereNotNull('trained')->get();
-        $users = [];
-        foreach ($usersRaw as $induction) {
-            if (isset($induction->user->name) && $induction->user->active) {
-                $users[$induction->key][] = $induction->user;
-            }
-        }
-        return $users;
-    }
 
     /**
      * @param string $device

--- a/app/Repo/InductionRepository.php
+++ b/app/Repo/InductionRepository.php
@@ -89,7 +89,7 @@ class InductionRepository extends DBRepository
      */
     public function getUsersPendingInduction()
     {
-        $usersRaw = $this->model->with('user', 'user.profile')->where('paid', true)->whereNull('trained')->get();
+        $usersRaw = $this->model->with('user', 'user.profile')->whereNull('trained')->get();
         $users = [];
         foreach ($usersRaw as $induction) {
             if (isset($induction->user->name) && $induction->user->active) {
@@ -104,7 +104,7 @@ class InductionRepository extends DBRepository
      */
     public function getTrainedUsers()
     {
-        $usersRaw = $this->model->with('user', 'user.profile')->where('paid', true)->whereNotNull('trained')->get();
+        $usersRaw = $this->model->with('user', 'user.profile')->whereNotNull('trained')->get();
         $users = [];
         foreach ($usersRaw as $induction) {
             if (isset($induction->user->name) && $induction->user->active) {
@@ -120,7 +120,7 @@ class InductionRepository extends DBRepository
      */
     public function getTrainedUsersForEquipment($device)
     {
-        $users = $this->model->with('user', 'user.profile')->where('paid', true)->whereNotNull('trained')->where('key', $device)->get();
+        $users = $this->model->with('user', 'user.profile')->whereNotNull('trained')->where('key', $device)->get();
         return $users->filter(function ($trainer) {
             return $trainer->user && $trainer->user->active;
         });
@@ -132,7 +132,7 @@ class InductionRepository extends DBRepository
      */
     public function getUsersPendingInductionForEquipment($device)
     {
-        $users = $this->model->with('user', 'user.profile')->where('paid', true)->where('key', $device)->whereNull('trained')->get();
+        $users = $this->model->with('user', 'user.profile')->where('key', $device)->whereNull('trained')->get();
         return $users->filter(function ($trainer) {
             return $trainer->user && $trainer->user->active;
         });
@@ -145,7 +145,7 @@ class InductionRepository extends DBRepository
      */
     public function isUserTrained($userId, $device)
     {
-        $record = $this->model->with('user', 'user.profile')->where('paid', true)->whereNotNull('trained')->where('user_id', $userId)->where('key', $device)->first();
+        $record = $this->model->with('user', 'user.profile')->whereNotNull('trained')->where('user_id', $userId)->where('key', $device)->first();
         if ($record) {
             return true;
         } else {
@@ -166,16 +166,6 @@ class InductionRepository extends DBRepository
             return $record;
         }
         return false;
-    }
-
-    /**
-     * Fetch an induction record by its associated payment
-     * @param $paymentId
-     * @return mixed
-     */
-    public function getByPaymentId($paymentId)
-    {
-        return $this->model->where('payment_id', $paymentId)->first();
     }
 
     public function getLeaderboard($timePeriod)

--- a/app/Repo/PaymentRepository.php
+++ b/app/Repo/PaymentRepository.php
@@ -292,18 +292,6 @@ class PaymentRepository extends DBRepository
     }
 
     /**
-     * @param string $referencePrefix
-     * @return \Illuminate\Database\Eloquent\Collection
-     */
-    public function getEquipmentFeePayments($referencePrefix)
-    {
-        return $this->model->where('reason', 'equipment-fee')->get()->filter(function ($payment) use ($referencePrefix) {
-            return strpos($payment->reference, ':' . $referencePrefix) !== false;
-        });
-    }
-
-
-    /**
      * Return a paginated list of balance affecting payment for a user
      * @param $userId
      * @return \Illuminate\Database\Eloquent\Collection

--- a/app/Services/Credit.php
+++ b/app/Services/Credit.php
@@ -72,8 +72,6 @@ class Credit
                 return 20;
             case 'subscription':
                 return 20;
-            case 'induction':
-                return 20;
             case 'equipment-fee':
                 return 20;
             default:

--- a/config/services.php
+++ b/config/services.php
@@ -31,6 +31,7 @@ return [
     ],
 
 	'telegram-bot-api' => [
+		'enabled' => !env('TELEGRAM_NOTIFICATIONS_DISABLED', false),
 		'token' => env('TELEGRAM_BOT_KEY', 'YOUR BOT TOKEN HERE')
 	],
 

--- a/database/factories/EquipmentFactory.php
+++ b/database/factories/EquipmentFactory.php
@@ -1,0 +1,55 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use BB\Entities\Equipment;
+use Faker\Generator as Faker;
+
+$factory->define(Equipment::class, function (Faker $faker) {
+    $name = $faker->unique()->word;
+    $slug = Str::slug($name);
+
+    return [
+        'name' => $name,
+        // 'manufacturer' => '',
+        // 'model_number' => '',
+        // 'serial_number' => '',
+        // 'colour' => '',
+        // 'location' => '',
+        // 'room' => '',
+        // 'detail' => '',
+        'slug' => $slug,
+        // 'description' => '',
+        // 'help_text' => '',
+        // 'managing_role_id' => '',
+        // 'requires_induction' => '',
+        // 'induction_category' => '',
+        // 'working' => '',
+        // 'permaloan' => '',
+        // 'permaloan_user_id' => '',
+        // 'access_fee' => '',
+        'photos' => [], // Not sure why this can be omitted when not creating via factories?
+        // 'archive' => '',
+        'obtained_at' => $faker->dateTimeThisYear,
+        // 'removed_at' => '',
+        // 'asset_tag_id' => '',
+        // 'usage_cost' => '',
+        'usage_cost_per' => 'hour',
+        // 'ppe' => '',
+        // 'dangerous' => '',
+        // 'induction_instructions' => '',
+        // 'trainer_instructions' => '',
+        // 'trained_instructions' => '',
+        // 'docs' => '',
+        // 'access_code' => '',
+        // 'accepting_inductions' => '',
+    ];
+});
+
+$factory->state(Equipment::class, 'requiresInduction', function (Faker $faker) {
+    return [
+        'requires_induction'  => true,
+        'induction_category'  => $faker->word,
+        'accepting_inductions' => true,
+    ];
+});

--- a/database/migrations/2024_12_30_012258_remove_payment_fields_from_inductions.php
+++ b/database/migrations/2024_12_30_012258_remove_payment_fields_from_inductions.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemovePaymentFieldsFromInductions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('inductions', function (Blueprint $table) {
+            $table->dropColumn(['paid', 'payment_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('inductions', function (Blueprint $table) {
+            $table->boolean('paid')->default(false);
+            $table->integer('payment_id')->default(0);
+        });
+    }
+}

--- a/database/migrations/2024_12_30_013230_make_trainer_user_id_column_nullable_for_inductions.php
+++ b/database/migrations/2024_12_30_013230_make_trainer_user_id_column_nullable_for_inductions.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class MakeTrainerUserIdColumnNullableForInductions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('inductions', function (Blueprint $table) {
+            $table->integer('trainer_user_id')->nullable()->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('inductions', function (Blueprint $table) {
+            $table->integer('trainer_user_id')->change();
+        });
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -28,5 +28,6 @@
         <server name="DB_DATABASE" value=":memory:"/>
         <server name="MAIL_DRIVER" value="log"/>
         <server name="FORCE_SECURE" value="false"/>
+        <server name="TELEGRAM_NOTIFICATIONS_DISABLED" value="true"/>
     </php>
 </phpunit>

--- a/resources/views/account/partials/induction-panel.blade.php
+++ b/resources/views/account/partials/induction-panel.blade.php
@@ -15,18 +15,12 @@
             <th>Cost</th>
             <th>Induction</th>
             <th>Access Code</th>
-            <th>
-                @if (Auth::user()->isAdmin())
-                Inducted Status
-                <span class="label label-danger">Admin</span>
-                @endif
-            </th>
-            <th>
-                @if (Auth::user()->isAdmin())
-                Can Induct Members
-                <span class="label label-danger">Admin</span>
-                @endif
-            </th>
+            @if (Auth::user()->isAdmin())
+                <th>
+                    Inducted Status
+                    <span class="label label-danger">Admin</span>
+                </th>
+            @endif
         </tr>
         </thead>
         <tbody>
@@ -52,27 +46,15 @@
                     @endif
                 @endif
             </td>
-            <td>
-                @if (Auth::user()->isAdmin() && $item->userInduction && !$item->userInduction->is_trained)
-                {!! Form::open(array('method'=>'PUT', 'route' => ['account.induction.update', $user->id, $item->userInduction->id])) !!}
-                {!! Form::text('trainer_user_id', '', ['class'=>'form-control']) !!}
-                {!! Form::hidden('mark_trained', '1') !!}
-                {!! Form::submit('Inducted By', array('class'=>'btn btn-default btn-xs')) !!}
-                {!! Form::close() !!}
-                @elseif ($item->userInduction && $item->userInduction->is_trained)
-                {{ $item->userInduction->trainer_user->name ?? 'inducted' }}
-                @endif
-            </td>
-            <td>
-                @if (Auth::user()->isAdmin() && $item->userInduction && $item->userInduction->is_trained && !$item->userInduction->is_trainer)
-                {!! Form::open(array('method'=>'PUT', 'route' => ['account.induction.update', $user->id, $item->userInduction->id])) !!}
-                {!! Form::hidden('is_trainer', '1') !!}
-                {!! Form::submit('Make a Trainer', array('class'=>'btn btn-default btn-xs')) !!}
-                {!! Form::close() !!}
-                @elseif ($item->userInduction && $item->userInduction->is_trained && $item->userInduction->is_trainer)
-                Yes
-                @endif
-            </td>
+            @if (Auth::user()->isAdmin())
+                <td>
+                    @if ($item->userInduction && !$item->userInduction->is_trained)
+                        Awaiting training
+                    @elseif ($item->userInduction && $item->userInduction->is_trained)
+                        {{ $item->userInduction->trainer_user->name ?? 'Inducted' }}
+                    @endif
+                </td>
+            @endif
         </tr>
         @endforeach
         </tbody>

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -111,8 +111,6 @@
                                     <p>
                                         Make a payment for your usage of this equipment below.
                                     </p>
-
-                                    <div class="paymentModule" data-reason="equipment-fee" data-display-reason="Usage Fee" data-button-label="Pay Now" data-methods="access_fee" data-ref="{{ $equipment->slug }}"></div>
                                 </div>
                             @endif
                         @else

--- a/routes/web.php
+++ b/routes/web.php
@@ -125,12 +125,13 @@ Route::post('account/payment/migrate-direct-debit', ['as' => 'account.payment.go
 ##########################
 
 Route::group(array('middleware' => 'role:member'), function () {
-    Route::post('equipment_training/create', ['uses' => 'InductionController@create', 'as' => 'equipment_training.create']);
-    Route::post('equipment_training/update', ['uses' => 'InductionController@update', 'as' => 'equipment_training.update']);
-    Route::resource('account.induction', 'InductionController', ['only' => ['update', 'destroy', 'create']]);
+    Route::post('equipment/{equipment}/induction', ['uses' => 'InductionController@store', 'as' => 'equipment_training.create']);
+    Route::post('equipment/{equipment}/induction/{induction}/train', ['uses' => 'InductionController@train', 'as' => 'equipment_training.train']);
+    Route::post('equipment/{equipment}/induction/{induction}/untrain', ['uses' => 'InductionController@untrain', 'as' => 'equipment_training.untrain']);
+    Route::post('equipment/{equipment}/induction/{induction}/promote', ['uses' => 'InductionController@promote', 'as' => 'equipment_training.promote']);
+    Route::post('equipment/{equipment}/induction/{induction}/demote', ['uses' => 'InductionController@demote', 'as' => 'equipment_training.demote']);
+    Route::delete('equipment/{equipment}/induction/{induction}', ['uses' => 'InductionController@destroy', 'as' => 'equipment_training.destroy']);
 });
-
-
 
 ##########################
 # Equipment

--- a/tests/InductionTest.php
+++ b/tests/InductionTest.php
@@ -1,0 +1,30 @@
+<?php
+
+use BB\Entities\Equipment;
+use BB\Entities\User;
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Tests\BrowserKitTestCase;
+
+class InductionTest extends BrowserKitTestCase
+{
+    use DatabaseMigrations;
+
+    public function test_can_request_own_induction()
+    {
+        $user = factory(User::class)->create();
+
+        $equipment = factory(Equipment::class)->state('requiresInduction')->create();
+
+        $this->actingAs($user);
+
+        $this->visit(route('equipment.show', $equipment))
+            ->press('Request induction')
+            ->see("Training to be completed");
+    }
+
+    public function x_test_trainers_can_request_inductions_for_others() {}
+
+    public function x_test_trainers_can_mark_as_trained() {}
+
+    public function x_test_trainers_can_promote_others_to_trainer() {}
+}


### PR DESCRIPTION
We no longer require paid inductions for any pieces of equipment, and we're also going to be reducing the ways we take digital payments to make our membership system easier to maintain.

The wider refactor here helped break out the individual actions that can take place against inductions, and brings this area of the codebase more in line with Laravel development practises.