### PR TITLE
Add maintainer groups to manage equipment permissions

### DIFF
--- a/app/Entities/Equipment.php
+++ b/app/Entities/Equipment.php
@@ -5,6 +5,8 @@ namespace BB\Entities;
 use BB\Scopes\OrderScope;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Laracasts\Presenter\PresentableTrait;
 
@@ -45,7 +47,7 @@ class Equipment extends Model
         'slug',
         'description',
         'help_text',
-        'managing_role_id',
+        'maintainer_group_id',
         'requires_induction',
         'induction_category',
         'working',
@@ -104,6 +106,11 @@ class Equipment extends Model
     public function role()
     {
         return $this->belongsTo('\BB\Entities\Role', 'managing_role_id');
+    }
+
+    public function maintainerGroup(): BelongsTo
+    {
+        return $this->belongsTo(MaintainerGroup::class);
     }
 
     /**

--- a/app/Entities/MaintainerGroup.php
+++ b/app/Entities/MaintainerGroup.php
@@ -2,17 +2,18 @@
 
 namespace BB\Entities;
 
-use BB\Entities\MaintainerGroup;
+use BB\Entities\EquipmentArea;
+use BB\Entities\User;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
-class EquipmentArea extends Model
+class MaintainerGroup extends Model
 {
     use SoftDeletes;
 
-    protected $fillable = ['name', 'slug', 'description'];
+    protected $fillable = ['name', 'slug', 'description', 'equipment_area_id'];
 
     /**
      * Get the route key for the model.
@@ -24,13 +25,13 @@ class EquipmentArea extends Model
         return 'slug';
     }
 
-    public function areaCoordinators(): BelongsToMany
+    public function maintainers(): BelongsToMany
     {
         return $this->belongsToMany(User::class);
     }
 
-    public function maintainerGroups(): HasMany
+    public function equipmentArea(): BelongsTo
     {
-        return $this->hasMany(MaintainerGroup::class);
+        return $this->belongsTo(EquipmentArea::class);
     }
 }

--- a/app/Entities/MaintainerGroup.php
+++ b/app/Entities/MaintainerGroup.php
@@ -7,6 +7,7 @@ use BB\Entities\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 class MaintainerGroup extends Model
@@ -33,5 +34,10 @@ class MaintainerGroup extends Model
     public function equipmentArea(): BelongsTo
     {
         return $this->belongsTo(EquipmentArea::class);
+    }
+
+    public function equipment(): HasMany
+    {
+        return $this->hasMany(Equipment::class);
     }
 }

--- a/app/Entities/User.php
+++ b/app/Entities/User.php
@@ -9,6 +9,7 @@ use DateTime;
 use Illuminate\Database\Eloquent\Model;
 use Laracasts\Presenter\PresentableTrait;
 use Auth;
+use BB\Entities\MaintainerGroup;
 use Hash;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Auth\Passwords\CanResetPassword;
@@ -227,6 +228,11 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
         return $this->belongsToMany(EquipmentArea::class);
     }
 
+    
+    public function maintainerGroups(): BelongsToMany
+    {
+        return $this->belongsToMany(MaintainerGroup::class);
+    }
 
     /*
     |--------------------------------------------------------------------------

--- a/app/Http/Controllers/EquipmentController.php
+++ b/app/Http/Controllers/EquipmentController.php
@@ -3,6 +3,7 @@
 namespace BB\Http\Controllers;
 
 use BB\Entities\Equipment;
+use BB\Entities\MaintainerGroup;
 use BB\Exceptions\ImageFailedException;
 use BB\Http\Requests\Equipment\StoreEquipmentRequest;
 use BB\Http\Requests\Equipment\UpdateEquipmentRequest;
@@ -134,11 +135,11 @@ class EquipmentController extends Controller
         $this->authorize('create', Equipment::class);
 
         $memberList = $this->userRepository->getAllAsDropdown();
-        $roleList = \BB\Entities\Role::pluck('title', 'id');
+        $maintainerGroupOptions = MaintainerGroup::orderBy('name', 'ASC')->pluck('name', 'id');
 
         return \View::make('equipment.create')
             ->with('memberList', $memberList)
-            ->with('roleList', $roleList->toArray())
+            ->with('maintainerGroupOptions', $maintainerGroupOptions->toArray())
             ->with('ppeList', $this->ppeList)
             ->with('trusted', true)
             ->with('isTrainerOrAdmin', \Auth::user()->isAdmin());
@@ -172,12 +173,12 @@ class EquipmentController extends Controller
         $this->authorize('update', $equipment);
 
         $memberList = $this->userRepository->getAllAsDropdown();
-        $roleList = \BB\Entities\Role::pluck('title', 'id');
+        $maintainerGroupOptions = MaintainerGroup::orderBy('name', 'ASC')->pluck('name', 'id');
 
         return \View::make('equipment.edit')
             ->with('equipment', $equipment)
             ->with('memberList', $memberList)
-            ->with('roleList', $roleList->toArray())
+            ->with('maintainerGroupOptions', $maintainerGroupOptions->toArray())
             ->with('ppeList', $this->ppeList);
     }
 

--- a/app/Http/Controllers/MaintainerGroupController.php
+++ b/app/Http/Controllers/MaintainerGroupController.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace BB\Http\Controllers;
+
+use BB\Entities\EquipmentArea;
+use BB\Entities\MaintainerGroup;
+use BB\Http\Requests\StoreMaintainerGroupRequest;
+use BB\Http\Requests\UpdateMaintainerGroupRequest;
+use BB\Repo\UserRepository;
+use FlashNotification;
+
+class MaintainerGroupController extends Controller
+{
+    /** @var UserRepository */
+    protected $userRepository;
+
+    public function __construct(UserRepository $userRepository)
+    {
+        $this->userRepository = $userRepository;
+        $this->authorizeResource(MaintainerGroup::class, 'maintainer_group');
+    }
+
+    /**
+     * Display a listing of the resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function index()
+    {
+        $maintainerGroups = MaintainerGroup::with('maintainers')->orderBy('name', 'ASC')->get();
+        return view('maintainer_groups.index', compact('maintainerGroups'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     *
+     * @return \Illuminate\Http\Response
+     */
+    public function create()
+    {
+        $memberList = $this->userRepository->getAllAsDropdown();
+        $equipmentAreaOptions = EquipmentArea::orderBy('name', 'ASC')->pluck('name', 'id');
+
+        return view('maintainer_groups.create', compact('memberList', 'equipmentAreaOptions'));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     *
+     * @param  StoreMaintainerGroupRequest  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function store(StoreMaintainerGroupRequest $request)
+    {
+        $maintainerGroup = MaintainerGroup::create($request->all());
+        $maintainerGroup->maintainers()->sync($request->input('maintainers'));
+
+        return redirect()->route('maintainer_groups.show', $maintainerGroup);
+    }
+
+    /**
+     * Display the specified resource.
+     *
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return \Illuminate\Http\Response
+     */
+    public function show(MaintainerGroup $maintainerGroup)
+    {
+        return view('maintainer_groups.show', compact('maintainerGroup'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     *
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return \Illuminate\Http\Response
+     */
+    public function edit(MaintainerGroup $maintainerGroup)
+    {
+        $memberList = $this->userRepository->getAllAsDropdown();
+        $equipmentAreaOptions = EquipmentArea::orderBy('name', 'ASC')->pluck('name', 'id');
+
+        return view('maintainer_groups.edit', compact('maintainerGroup', 'memberList', 'equipmentAreaOptions'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     *
+     * @param  UpdateMaintainerGroupRequest  $request
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return \Illuminate\Http\Response
+     */
+    public function update(UpdateMaintainerGroupRequest $request, MaintainerGroup $maintainerGroup)
+    {
+        $maintainerGroup->update($request->all());
+        $maintainerGroup->maintainers()->sync($request->input('maintainers'));
+
+        return redirect()->route('maintainer_groups.show', $maintainerGroup);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     *
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return \Illuminate\Http\Response
+     */
+    public function destroy(MaintainerGroup $maintainerGroup)
+    {
+        $maintainerGroup->delete();
+        FlashNotification::success("Equipment Area, {$maintainerGroup->name}, deleted successfully.");
+
+        return redirect()->route('maintainer_groups.index');
+    }
+}

--- a/app/Http/Requests/Equipment/StoreEquipmentRequest.php
+++ b/app/Http/Requests/Equipment/StoreEquipmentRequest.php
@@ -34,7 +34,7 @@ class StoreEquipmentRequest extends FormRequest
             'slug'                      => 'required|alpha_dash|unique:equipment,slug',
             'description'               => '',
             'help_text'                 => '',
-            'managing_role_id'          => 'exists:roles,id',
+            'maintainer_group_id'       => 'exists:maintainer_groups,id',
             'requires_induction'        => 'boolean',
             'induction_category'        => 'required_if:requires_induction,1|alpha_dash',
             'working'                   => 'boolean',

--- a/app/Http/Requests/Equipment/StoreEquipmentRequest.php
+++ b/app/Http/Requests/Equipment/StoreEquipmentRequest.php
@@ -2,6 +2,7 @@
 
 namespace BB\Http\Requests\Equipment;
 
+use BB\Entities\MaintainerGroup;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -47,7 +48,11 @@ class StoreEquipmentRequest extends FormRequest
                         return;
                     }
 
-                    if (!$this->user()->maintainerGroups->contains($value)) {
+                    $maintainerGroup = MaintainerGroup::find($value);
+                    $inMaintainerGroup = $this->user()->maintainerGroups->contains($maintainerGroup);
+                    $isAreaCoordinator = $this->user()->equipmentAreas->contains($maintainerGroup->equipmentArea);
+
+                    if (!$inMaintainerGroup && !$isAreaCoordinator) {
                         $fail('You can only create equipment managed by maintainer groups you are in.');
                     }
                 }

--- a/app/Http/Requests/StoreMaintainerGroupRequest.php
+++ b/app/Http/Requests/StoreMaintainerGroupRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace BB\Http\Requests;
+
+use BB\Entities\MaintainerGroup;
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreMaintainerGroupRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return $this->user()->can('create', MaintainerGroup::class);
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'name' => ['required', 'unique:maintainer_groups'],
+            'slug' => ['required', 'unique:maintainer_groups'],
+            'description' => [],
+            'equipment_area_id' => ['required', 'integer', 'exists:equipment_areas,id'],
+            'maintainers' => ['array', 'exists:users,id'],
+        ];
+    }
+}

--- a/app/Http/Requests/UpdateMaintainerGroupRequest.php
+++ b/app/Http/Requests/UpdateMaintainerGroupRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BB\Http\Requests;
+
+use BB\Entities\MaintainerGroup;
+use Illuminate\Validation\Rule;
+
+class UpdateMaintainerGroupRequest extends StoreMaintainerGroupRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        /** @var MaintainerGroup */
+        $maintainerGroup = $this->route('maintainer_group');
+        return $this->user()->can('update', $maintainerGroup);
+    }
+
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        /** @var MaintainerGroup */
+        $maintainerGroup = $this->route('maintainer_group');
+
+        return array_merge(
+            parent::rules(),
+            [
+                'name' => ['required', Rule::unique('maintainer_groups')->ignore($maintainerGroup->id)],
+                'slug' => ['required', Rule::unique('maintainer_groups')->ignore($maintainerGroup->id)],
+            ]
+        );
+    }
+}

--- a/app/Policies/EquipmentAreaPolicy.php
+++ b/app/Policies/EquipmentAreaPolicy.php
@@ -25,7 +25,7 @@ class EquipmentAreaPolicy
      * Determine whether the user can view the equipment area.
      *
      * @param  \BB\Entities\User  $user
-     * @param  \BB\EquipmentArea  $equipmentArea
+     * @param  \BB\Entities\EquipmentArea  $equipmentArea
      * @return mixed
      */
     public function view(User $user, EquipmentArea $equipmentArea)
@@ -48,7 +48,7 @@ class EquipmentAreaPolicy
      * Determine whether the user can update the equipment area.
      *
      * @param  \BB\Entities\User  $user
-     * @param  \BB\EquipmentArea  $equipmentArea
+     * @param  \BB\Entities\EquipmentArea  $equipmentArea
      * @return mixed
      */
     public function update(User $user, EquipmentArea $equipmentArea)
@@ -60,7 +60,7 @@ class EquipmentAreaPolicy
      * Determine whether the user can delete the equipment area.
      *
      * @param  \BB\Entities\User  $user
-     * @param  \BB\EquipmentArea  $equipmentArea
+     * @param  \BB\Entities\EquipmentArea  $equipmentArea
      * @return mixed
      */
     public function delete(User $user, EquipmentArea $equipmentArea)
@@ -72,7 +72,7 @@ class EquipmentAreaPolicy
      * Determine whether the user can restore the equipment area.
      *
      * @param  \BB\Entities\User  $user
-     * @param  \BB\EquipmentArea  $equipmentArea
+     * @param  \BB\Entities\EquipmentArea  $equipmentArea
      * @return mixed
      */
     public function restore(User $user, EquipmentArea $equipmentArea)
@@ -84,7 +84,7 @@ class EquipmentAreaPolicy
      * Determine whether the user can permanently delete the equipment area.
      *
      * @param  \BB\Entities\User  $user
-     * @param  \BB\EquipmentArea  $equipmentArea
+     * @param  \BB\Entities\EquipmentArea  $equipmentArea
      * @return mixed
      */
     public function forceDelete(User $user, EquipmentArea $equipmentArea)

--- a/app/Policies/EquipmentPolicy.php
+++ b/app/Policies/EquipmentPolicy.php
@@ -49,7 +49,9 @@ class EquipmentPolicy
     public function create(User $user)
     {
         // If they're in a maintainer group, they can create equipment managed by their group
-        return $user->maintainerGroups()->count() > 0;
+        $isMaintainer =  $user->maintainerGroups()->count() > 0;
+        $isAreaCoordinator = $user->equipmentAreas()->count() > 0;
+        return $isMaintainer || $isAreaCoordinator;
     }
 
     /**
@@ -62,9 +64,10 @@ class EquipmentPolicy
     public function update(User $user, Equipment $equipment)
     {
         $inMaintainerGroup = $user->maintainerGroups->contains($equipment->maintainerGroup);
+        $isAreaCoordinator = $user->equipmentAreas->contains($equipment->maintainerGroup->equipmentArea);
         $inManagingRole = $equipment->role ? $user->hasRole($equipment->role->name) : false;
 
-        return $inMaintainerGroup || $inManagingRole;
+        return $inMaintainerGroup || $isAreaCoordinator || $inManagingRole;
     }
 
     /**
@@ -77,9 +80,10 @@ class EquipmentPolicy
     public function delete(User $user, Equipment $equipment)
     {
         $inMaintainerGroup = $user->maintainerGroups->contains($equipment->maintainerGroup);
+        $isAreaCoordinator = $user->equipmentAreas->contains($equipment->maintainerGroup->equipmentArea);
         $inManagingRole = $equipment->role ? $user->hasRole($equipment->role->name) : false;
 
-        return $inMaintainerGroup || $inManagingRole;
+        return $inMaintainerGroup || $isAreaCoordinator || $inManagingRole;
     }
 
     public function train(User $user, Equipment $equipment)

--- a/app/Policies/EquipmentPolicy.php
+++ b/app/Policies/EquipmentPolicy.php
@@ -60,7 +60,10 @@ class EquipmentPolicy
      */
     public function update(User $user, Equipment $equipment)
     {
-        return $equipment->role ? $user->hasRole($equipment->role->name) : false;
+        $inMaintainerGroup = $user->maintainerGroups->contains($equipment->maintainerGroup);
+        $inManagingRole = $equipment->role ? $user->hasRole($equipment->role->name) : false;
+
+        return $inMaintainerGroup || $inManagingRole;
     }
 
     /**
@@ -72,7 +75,10 @@ class EquipmentPolicy
      */
     public function delete(User $user, Equipment $equipment)
     {
-        return $equipment->role ? $user->hasRole($equipment->role->name) : false;
+        $inMaintainerGroup = $user->maintainerGroups->contains($equipment->maintainerGroup);
+        $inManagingRole = $equipment->role ? $user->hasRole($equipment->role->name) : false;
+
+        return $inMaintainerGroup || $inManagingRole;
     }
 
     public function train(User $user, Equipment $equipment)

--- a/app/Policies/EquipmentPolicy.php
+++ b/app/Policies/EquipmentPolicy.php
@@ -48,7 +48,8 @@ class EquipmentPolicy
      */
     public function create(User $user)
     {
-        return false;
+        // If they're in a maintainer group, they can create equipment managed by their group
+        return $user->maintainerGroups()->count() > 0;
     }
 
     /**

--- a/app/Policies/MaintainerGroupPolicy.php
+++ b/app/Policies/MaintainerGroupPolicy.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BB\Policies;
+
+use BB\Entities\User;
+use BB\Entities\MaintainerGroup;
+use Illuminate\Auth\Access\HandlesAuthorization;
+
+class MaintainerGroupPolicy
+{
+    use HandlesAuthorization;
+
+    /**
+     * Determine whether the user can view any maintainer groups.
+     *
+     * @param  \BB\Entities\User  $user
+     * @return mixed
+     */
+    public function viewAny(User $user)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the maintainer group.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return mixed
+     */
+    public function view(User $user, MaintainerGroup $maintainerGroup)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can create maintainer groups.
+     *
+     * @param  \BB\Entities\User  $user
+     * @return mixed
+     */
+    public function create(User $user)
+    {
+        // TODO: Make it possible for area coordinators to make new groups under their area
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can update the maintainer group.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return mixed
+     */
+    public function update(User $user, MaintainerGroup $maintainerGroup)
+    {
+        return $user->isAdmin() || $maintainerGroup->maintainers->contains($user);
+    }
+
+    /**
+     * Determine whether the user can delete the maintainer group.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return mixed
+     */
+    public function delete(User $user, MaintainerGroup $maintainerGroup)
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can restore the maintainer group.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return mixed
+     */
+    public function restore(User $user, MaintainerGroup $maintainerGroup)
+    {
+        return $user->isAdmin();
+    }
+
+    /**
+     * Determine whether the user can permanently delete the maintainer group.
+     *
+     * @param  \BB\Entities\User  $user
+     * @param  \BB\Entities\MaintainerGroup  $maintainerGroup
+     * @return mixed
+     */
+    public function forceDelete(User $user, MaintainerGroup $maintainerGroup)
+    {
+        return $user->isAdmin();
+    }
+}

--- a/app/Policies/MaintainerGroupPolicy.php
+++ b/app/Policies/MaintainerGroupPolicy.php
@@ -10,6 +10,16 @@ class MaintainerGroupPolicy
 {
     use HandlesAuthorization;
 
+    public function before($user, $ability)
+    {
+        if ($user->isAdmin()) {
+            return true;
+        }
+
+        // fall through to policy methods
+        return null;
+    }
+
     /**
      * Determine whether the user can view any maintainer groups.
      *
@@ -41,8 +51,8 @@ class MaintainerGroupPolicy
      */
     public function create(User $user)
     {
-        // TODO: Make it possible for area coordinators to make new groups under their area
-        return $user->isAdmin();
+        // Area coordinators can make maintainer groups
+        return $user->equipmentAreas()->count() > 0;
     }
 
     /**
@@ -54,7 +64,10 @@ class MaintainerGroupPolicy
      */
     public function update(User $user, MaintainerGroup $maintainerGroup)
     {
-        return $user->isAdmin() || $maintainerGroup->maintainers->contains($user);
+        $isMaintainer = $maintainerGroup->maintainers->contains($user);
+        $isAreaCoordinator = $user->equipmentAreas->contains($maintainerGroup->equipmentArea);
+
+        return $isMaintainer || $isAreaCoordinator;
     }
 
     /**
@@ -66,7 +79,10 @@ class MaintainerGroupPolicy
      */
     public function delete(User $user, MaintainerGroup $maintainerGroup)
     {
-        return $user->isAdmin();
+        $isMaintainer = $maintainerGroup->maintainers->contains($user);
+        $isAreaCoordinator = $user->equipmentAreas->contains($maintainerGroup->equipmentArea);
+
+        return $isMaintainer || $isAreaCoordinator;
     }
 
     /**
@@ -78,7 +94,7 @@ class MaintainerGroupPolicy
      */
     public function restore(User $user, MaintainerGroup $maintainerGroup)
     {
-        return $user->isAdmin();
+        return false;
     }
 
     /**
@@ -90,6 +106,6 @@ class MaintainerGroupPolicy
      */
     public function forceDelete(User $user, MaintainerGroup $maintainerGroup)
     {
-        return $user->isAdmin();
+        return false;
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -10,10 +10,12 @@ use BB\Entities\Induction;
 use BB\Entities\KeyFob;
 use BB\Entities\StorageBox;
 use BB\Entities\User;
+use BB\Entities\MaintainerGroup;
 use BB\Policies\EquipmentAreaPolicy;
 use BB\Policies\EquipmentPolicy;
 use BB\Policies\InductionPolicy;
 use BB\Policies\KeyFobPolicy;
+use BB\Policies\MaintainerGroupPolicy;
 use BB\Policies\StorageBoxPolicy;
 use BB\Policies\UserPolicy;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
@@ -32,6 +34,7 @@ class AuthServiceProvider extends ServiceProvider
         StorageBox::class => StorageBoxPolicy::class,
         EquipmentArea::class => EquipmentAreaPolicy::class,
         Induction::class => InductionPolicy::class,
+        MaintainerGroup::class => MaintainerGroupPolicy::class,
     ];
 
     /**

--- a/app/Repo/DBRepository.php
+++ b/app/Repo/DBRepository.php
@@ -50,6 +50,11 @@ abstract class DBRepository
      */
     public function create($data)
     {
+        // Can remove if we ever add the ConvertEmptyStringsToNull middleware
+        if (is_string($data['maintainer_group_id']) && $data['maintainer_group_id'] == '') {
+            $data['maintainer_group_id'] = null;
+        }
+        
         return $this->model->create($data);
     }
 
@@ -74,6 +79,11 @@ abstract class DBRepository
      */
     public function update($recordId, $recordData)
     {
+        // Can remove if we ever add the ConvertEmptyStringsToNull middleware
+        if (is_string($recordData['maintainer_group_id']) && $recordData['maintainer_group_id'] == '') {
+            $recordData['maintainer_group_id'] = null;
+        }
+
         return $this->getById($recordId)->update($recordData);
     }
 

--- a/database/factories/MaintainerGroupFactory.php
+++ b/database/factories/MaintainerGroupFactory.php
@@ -1,0 +1,14 @@
+<?php
+
+/** @var \Illuminate\Database\Eloquent\Factory $factory */
+
+use BB\Entities\MaintainerGroup;
+use Faker\Generator as Faker;
+
+$factory->define(MaintainerGroup::class, function (Faker $faker) {
+    return [
+        'name' => $faker->unique()->word,
+        'slug' => $faker->unique()->slug,
+        'description' => $faker->sentence,
+    ];
+});

--- a/database/migrations/2025_02_10_212748_create_maintainer_groups_table.php
+++ b/database/migrations/2025_02_10_212748_create_maintainer_groups_table.php
@@ -1,0 +1,50 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMaintainerGroupsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('maintainer_groups', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->string('name')->unique();
+            $table->string('slug')->unique();
+            $table->string('description');
+
+            $table->unsignedBigInteger('equipment_area_id')->nullable();
+            $table->foreign('equipment_area_id')->references('id')->on('equipment_areas');
+        });
+
+        Schema::create('maintainer_group_user', function(Blueprint $table) {
+            $table->timestamps();
+
+            $table->unsignedBigInteger('maintainer_group_id');
+            $table->unsignedInteger('user_id');
+
+            $table->foreign('maintainer_group_id')->references('id')->on('maintainer_groups');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('maintainer_groups');
+        Schema::dropIfExists('maintainer_group_users');
+    }
+}

--- a/database/migrations/2025_02_10_222951_add_maintainer_group_id_to_equipment.php
+++ b/database/migrations/2025_02_10_222951_add_maintainer_group_id_to_equipment.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMaintainerGroupIdToEquipment extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('equipment', function (Blueprint $table) {
+            
+            $table->unsignedBigInteger('maintainer_group_id')->nullable();
+            $table->foreign('maintainer_group_id')->references('id')->on('maintainer_groups');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('equipment', function (Blueprint $table) {
+            $table->dropColumn('maintainer_group_id');
+        });
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -331,6 +331,41 @@ parameters:
 			path: app/Http/Controllers/LeaderboardController.php
 
 		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:create\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\View\\\\View\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:destroy\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\RedirectResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:edit\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\View\\\\View\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:index\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\View\\\\View\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:show\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\View\\\\View\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:store\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\RedirectResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
+			message: "#^Method BB\\\\Http\\\\Controllers\\\\MaintainerGroupController\\:\\:update\\(\\) should return Illuminate\\\\Http\\\\Response but returns Illuminate\\\\Http\\\\RedirectResponse\\.$#"
+			count: 1
+			path: app/Http/Controllers/MaintainerGroupController.php
+
+		-
 			message: "#^PHPDoc tag @var has invalid value \\(\\)\\: Unexpected token \"\\\\n     \", expected type at offset 15$#"
 			count: 1
 			path: app/Http/Controllers/MembersController.php
@@ -699,36 +734,6 @@ parameters:
 			message: "#^Access to an undefined property Illuminate\\\\Contracts\\\\Auth\\\\Authenticatable\\:\\:\\$id\\.$#"
 			count: 1
 			path: app/Observer/UserAuditObserver.php
-
-		-
-			message: "#^PHPDoc tag @param for parameter \\$equipmentArea with type BB\\\\EquipmentArea is not subtype of native type BB\\\\Entities\\\\EquipmentArea\\.$#"
-			count: 5
-			path: app/Policies/EquipmentAreaPolicy.php
-
-		-
-			message: "#^Parameter \\$equipmentArea of method BB\\\\Policies\\\\EquipmentAreaPolicy\\:\\:delete\\(\\) has invalid type BB\\\\EquipmentArea\\.$#"
-			count: 1
-			path: app/Policies/EquipmentAreaPolicy.php
-
-		-
-			message: "#^Parameter \\$equipmentArea of method BB\\\\Policies\\\\EquipmentAreaPolicy\\:\\:forceDelete\\(\\) has invalid type BB\\\\EquipmentArea\\.$#"
-			count: 1
-			path: app/Policies/EquipmentAreaPolicy.php
-
-		-
-			message: "#^Parameter \\$equipmentArea of method BB\\\\Policies\\\\EquipmentAreaPolicy\\:\\:restore\\(\\) has invalid type BB\\\\EquipmentArea\\.$#"
-			count: 1
-			path: app/Policies/EquipmentAreaPolicy.php
-
-		-
-			message: "#^Parameter \\$equipmentArea of method BB\\\\Policies\\\\EquipmentAreaPolicy\\:\\:update\\(\\) has invalid type BB\\\\EquipmentArea\\.$#"
-			count: 1
-			path: app/Policies/EquipmentAreaPolicy.php
-
-		-
-			message: "#^Parameter \\$equipmentArea of method BB\\\\Policies\\\\EquipmentAreaPolicy\\:\\:view\\(\\) has invalid type BB\\\\EquipmentArea\\.$#"
-			count: 1
-			path: app/Policies/EquipmentAreaPolicy.php
 
 		-
 			message: "#^Access to an undefined property BB\\\\Entities\\\\Equipment\\:\\:\\$role\\.$#"

--- a/resources/views/equipment/form.blade.php
+++ b/resources/views/equipment/form.blade.php
@@ -183,13 +183,13 @@
         </div>
     </div>
     <div class="col-md-6">
-        <div class="{{ $errors->has('managing_role_id') ? 'has-error' : '' }}">
-            {!! Form::label('managing_role_id', 'Managing Group', ['class'=>'']) !!}
-            {!! Form::select('managing_role_id', [''=>'']+$roleList, null, ['class'=>'form-control js-advanced-dropdown']) !!}
+        <div class="{{ $errors->has('maintainer_group_id') ? 'has-error' : '' }}">
+            {!! Form::label('maintainer_group_id', 'Maintainer Group', ['class'=>'']) !!}
+            {!! Form::select('maintainer_group_id', [''=>'']+$maintainerGroupOptions, null, ['class'=>'form-control js-advanced-dropdown']) !!}
             <p class="help-block">Is a group is responsible for this piece of equipment?</p>
-            @if($errors->has('managing_role_id'))
+            @if($errors->has('maintainer_group_id'))
                 <span class="help-block">
-                    @foreach($errors->get('managing_role_id') as $error)
+                    @foreach($errors->get('maintainer_group_id') as $error)
                         <li>{{ $error }}</li>
                     @endforeach
                 </span>

--- a/resources/views/equipment/form.blade.php
+++ b/resources/views/equipment/form.blade.php
@@ -185,7 +185,7 @@
     <div class="col-md-6">
         <div class="{{ $errors->has('maintainer_group_id') ? 'has-error' : '' }}">
             {!! Form::label('maintainer_group_id', 'Maintainer Group', ['class'=>'']) !!}
-            {!! Form::select('maintainer_group_id', [''=>'']+$maintainerGroupOptions, null, ['class'=>'form-control js-advanced-dropdown']) !!}
+            {!! Form::select('maintainer_group_id', [null => 'Please select...']+$maintainerGroupOptions, null, ['class'=>'form-control js-advanced-dropdown']) !!}
             <p class="help-block">Is a group is responsible for this piece of equipment?</p>
             @if($errors->has('maintainer_group_id'))
                 <span class="help-block">

--- a/resources/views/equipment/show.blade.php
+++ b/resources/views/equipment/show.blade.php
@@ -134,6 +134,18 @@
                                 </div>
                             </div>
                         @endif
+                        @if ($equipment->maintainerGroup)
+                            <div class="tool-info__detail">
+                                <div class="tool-info__key">
+                                    Maintainer by
+                                </div>
+                                <div class="tool-info__value">
+                                    <a href="{{ route('maintainer_groups.show', $equipment->maintainerGroup) }}">
+                                        🛠️ {{ $equipment->maintainerGroup->name }}
+                                    </a>
+                                </div>
+                            </div>
+                        @endif
                         
                         <div class="tool-info__detail">
                             <div class="tool-info__key">

--- a/resources/views/maintainer_groups/create.blade.php
+++ b/resources/views/maintainer_groups/create.blade.php
@@ -1,0 +1,19 @@
+@extends('layouts.main')
+
+@section('meta-title')
+    Add a maintainer group
+@stop
+
+@section('page-title')
+    <a href="{{ route('maintainer_groups.index') }}">Maintainer Groups</a> > Create
+@stop
+
+@section('content')
+    {!! Form::open(['route' => 'maintainer_groups.store']) !!}
+
+    @include('maintainer_groups/form')
+
+    {!! Form::submit('Save', ['class' => 'btn btn-primary']) !!}
+
+    {!! Form::close() !!}
+@stop

--- a/resources/views/maintainer_groups/edit.blade.php
+++ b/resources/views/maintainer_groups/edit.blade.php
@@ -1,0 +1,24 @@
+@extends('layouts.main')
+
+@section('meta-title')
+    Edit a maintainer group
+@stop
+
+@section('page-title')
+    <a href="{{ route('maintainer_groups.index') }}">Maintainer Groups</a> >
+    <a href="{{ route('maintainer_groups.show', $maintainerGroup->slug) }}">{{ $maintainerGroup->name }}</a> >
+    Edit
+@stop
+
+@section('content')
+    {!! Form::model($maintainerGroup, [
+        'route' => ['maintainer_groups.update', $maintainerGroup],
+        'method' => 'PUT',
+    ]) !!}
+
+    @include('maintainer_groups/form')
+
+    {!! Form::submit('Update', ['class' => 'btn btn-primary']) !!}
+
+    {!! Form::close() !!}
+@stop

--- a/resources/views/maintainer_groups/form.blade.php
+++ b/resources/views/maintainer_groups/form.blade.php
@@ -1,0 +1,79 @@
+@if($errors->any())
+    <div class="alert alert-danger">
+        <ul>
+            @foreach ($errors->all() as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </ul>
+    </div>
+@endif
+
+<div class="form-group">
+    <div class="{{ $errors->has('name') ? 'has-error' : '' }}">
+        {!! Form::label('name', 'Name', ['class'=>'']) !!}
+        {!! Form::text('name', null, ['class'=>'form-control', 'required']) !!}
+        <p class="help-block">Aim for a short but descriptive name, i.e. Visual Arts</p>
+        @if($errors->has('name'))
+            <span class="help-block">
+                @foreach($errors->get('name') as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </span>
+        @endif
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="{{ $errors->has('slug') ? 'has-error' : '' }}">
+        {!! Form::label('slug', 'Slug', ['class'=>'']) !!}
+        {!! Form::text('slug', null, ['class'=>'form-control', 'required']) !!}
+        <p class="help-block">This is the unique reference for the area, no special characters. i.e. woodwork or sewing-machines</p>
+        @if($errors->has('slug'))
+            <span class="help-block">
+                @foreach($errors->get('slug') as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </span>
+        @endif        
+    </div>
+</div>
+
+<div class="form-group">
+    <div class="{{ $errors->has('description') ? 'has-error' : '' }}">
+        {!! Form::label('description', 'Description', ['class'=>'']) !!}
+        {!! Form::textarea('description', null, ['class'=>'form-control']) !!}
+        @if($errors->has('description'))
+            <span class="help-block">
+                @foreach($errors->get('description') as $error)
+                    <li>{{ $error }}</li>
+                @endforeach
+            </span>
+        @endif        
+    </div>
+</div>
+
+<div class="form-group {{ $errors->has('equipment_area_id') ? 'has-error' : '' }}">
+    {!! Form::label('equipment_area_id', 'Represented by area', ['class'=>'col-sm-3 control-label']) !!}
+    
+    {!! Form::select('equipment_area_id', ['' => 'Please select...'] + $equipmentAreaOptions->toArray(), null, ['class'=>'form-control']) !!}
+    @if($errors->has('equipment_area_id'))
+        <span class="help-block">
+            @foreach($errors->get('equipment_area_id') as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </span>
+    @endif
+</div>
+
+<div class="form-group {{ $errors->has('maintainers') ? 'has-error' : '' }}">
+    {!! Form::label('maintainers', 'Maintainers', ['class'=>'col-sm-3 control-label']) !!}
+    
+    {!! Form::select('maintainers[]', $memberList, null, ['class'=>'form-control js-advanced-dropdown', 'multiple']) !!}
+    @if($errors->has('maintainers'))
+        <span class="help-block">
+            @foreach($errors->get('maintainers') as $error)
+                <li>{{ $error }}</li>
+            @endforeach
+        </span>
+    @endif
+</div>

--- a/resources/views/maintainer_groups/index.blade.php
+++ b/resources/views/maintainer_groups/index.blade.php
@@ -1,0 +1,59 @@
+@extends('layouts.main')
+
+@section('meta-title')
+    Maintainer Groups
+@stop
+
+@section('page-title')
+    Maintainer Groups
+@stop
+
+@section('page-action-buttons')
+    @if (!Auth::guest() && Auth::user()->can('create', \BB\Entities\MaintainerGroup::class))
+        <a class="btn btn-secondary" href="{{ route('maintainer_groups.create') }}">Create maintainer group</a>
+    @endif
+@stop
+
+@section('content')
+
+    <div class="row">
+        <div class="col-sm-12 col-md-9 col-lg-9">
+            <div class="well">
+                <p>Our maintainer groups are responsible for looking after various pieces of equipment at the Hackspace.</p>
+                <p>If you want to get involved and help look after our equipment, please speak to the relevant area coordinators.</p>
+            </div>
+            @foreach ($maintainerGroups as $maintainerGroup)
+                <div class="well">
+                    <a href="{{ route('maintainer_groups.show', $maintainerGroup) }}" class="">
+                        <h4 class="list-group-item-heading">{{ $maintainerGroup->name }}</h4>
+                    </a>
+                    
+                    @if ($maintainerGroup->equipmentArea)
+                        <a href="{{ route('equipment_area.show', $maintainerGroup->equipmentArea) }}">
+                            <span class="label label-default">{{ $maintainerGroup->equipmentArea->name }}</span>
+                        </a>
+                    @endif
+                    
+                    <p class="list-group-item-text">
+                        {{ $maintainerGroup->description }}
+                    </p>
+                    
+
+                    <h5>Maintainers</h5>
+                    <ul class="list-group">
+                        @foreach ($maintainerGroup->maintainers as $maintainer)
+                            <li class="list-group-item">
+                                <a href="{{ route('members.show', $maintainer->id) }}">
+                                    {!! HTML::memberPhoto($maintainer->profile, $maintainer->hash, 64, 'hidden-sm hidden-xs') !!}
+                                    <span>{{ $maintainer->name }}</span>
+                                </a>
+                            </li>
+                        @endforeach
+                    </ul>
+                </div>
+            @endforeach
+
+        </div>
+    </div>
+
+@stop

--- a/resources/views/maintainer_groups/show.blade.php
+++ b/resources/views/maintainer_groups/show.blade.php
@@ -44,6 +44,19 @@
         </ul>
     </div>
 
+    <div class="well">
+        <h3>Equipment</h3>
+        <ul class="list-group">
+            @foreach ($maintainerGroup->equipment as $equipment)
+                <li class="list-group-item">
+                    <a href="{{ route('equipment.show', $equipment) }}">
+                        <span>{{ $equipment->name }}</span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+
     @can('delete', $maintainerGroup)
         <div class="modal fade" tabindex="-1" role="dialog" id="equipment-area-deletion-modal">
             <form class="modal-dialog" role="document" action="{{ route('maintainer_groups.destroy', $maintainerGroup) }}"

--- a/resources/views/maintainer_groups/show.blade.php
+++ b/resources/views/maintainer_groups/show.blade.php
@@ -1,0 +1,72 @@
+@extends('layouts.main')
+
+@section('meta-title')
+    {{ $maintainerGroup->name }}
+@stop
+
+@section('page-title')
+    <a href="{{ route('maintainer_groups.index') }}">Maintainer Groups</a> > {{ $maintainerGroup->name }}
+@stop
+
+@section('page-action-buttons')
+    @can('update', $maintainerGroup)
+        <a class="btn btn-secondary" href="{{ route('maintainer_groups.edit', $maintainerGroup) }}">Edit</a>
+    @endcan
+    @can('delete', $maintainerGroup)
+        <button class="btn btn-danger" data-toggle="modal" data-target="#equipment-area-deletion-modal">Delete</button>
+    @endcan
+@stop
+
+@section('content')
+    <div class="well">
+        @if ($maintainerGroup->equipmentArea)
+            <h3>Area</h3>
+            <a href="{{ route('equipment_area.show', $maintainerGroup->equipmentArea) }}">
+                {{ $maintainerGroup->equipmentArea->name }}
+            </a>
+        @endif
+
+        <h3>Description</h3>
+        {{ $maintainerGroup->description }}
+    </div>
+
+    <div class="well">
+        <h3>Maintainers</h3>
+        <ul class="list-group">
+            @foreach ($maintainerGroup->maintainers as $maintainer)
+                <li class="list-group-item">
+                    <a href="{{ route('members.show', $maintainer->id) }}">
+                        {!! HTML::memberPhoto($maintainer->profile, $maintainer->hash, 64) !!}
+                        <span>{{ $maintainer->name }}</span>
+                    </a>
+                </li>
+            @endforeach
+        </ul>
+    </div>
+
+    @can('delete', $maintainerGroup)
+        <div class="modal fade" tabindex="-1" role="dialog" id="equipment-area-deletion-modal">
+            <form class="modal-dialog" role="document" action="{{ route('maintainer_groups.destroy', $maintainerGroup) }}"
+                method="POST">
+                {{ csrf_field() }}
+                {{ method_field('DELETE') }}
+
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span
+                                aria-hidden="true">&times;</span></button>
+                        <h4 class="modal-title">Confirm deletion</h4>
+                    </div>
+                    <div class="modal-body">
+                        <p>Deleting <em>{{ $maintainerGroup->name }}</em> will remove it from the members system entirely.</p>
+                        <p>Are you sure you want to delete this item?</p>
+                    </div>
+                    <div class="modal-footer">
+                        <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                        <button type="submit" class="btn btn-danger">Save changes</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    @endcan
+@stop

--- a/resources/views/partials/main-sidenav.blade.php
+++ b/resources/views/partials/main-sidenav.blade.php
@@ -184,6 +184,7 @@
             {!! HTML::sideNavLink('Tools and Equipment', 'equipment.index') !!}
             {!! HTML::sideNavLink('Stats', 'stats.index') !!}
             {!! HTML::sideNavLink('Area Coordinators', 'equipment_area.index') !!}
+            {!! HTML::sideNavLink('Maintainer Groups', 'maintainer_groups.index') !!}
             
             @if(!Auth::guest())
                 @if (Auth::user()->isAdmin())

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,6 +148,12 @@ Route::group(array('middleware' => 'role:member'), function () {
 Route::resource('equipment_area', 'EquipmentAreaController');
 
 ##########################
+# Maintainer groups
+##########################
+
+Route::resource('maintainer_groups', 'MaintainerGroupController');
+
+##########################
 # Notifications
 ##########################
 


### PR DESCRIPTION
Make these groups less opaque, as well as actually let them create equipment areas under their group rather than globally.